### PR TITLE
Workflows - run CodeQL and ADR report publishing after main workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "dotnet"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,11 @@
 name: "Code Scanning - Action"
-
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ['.NET'] # runs after .NET workflow
+    types:
+      - completed
+    branches:
+      - 'main'
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,6 @@ name: "Code Scanning - Action"
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/publish-log4brains.yml
+++ b/.github/workflows/publish-log4brains.yml
@@ -1,8 +1,11 @@
 name: Publish Log4brains
 on:
-  push:
+  workflow_run:
+    workflows: ['.NET'] # runs after .NET workflow
+    types:
+      - completed
     branches:
-      - main
+      - 'main'
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Doing this as per https://github.com/dorny/test-reporter/issues/67

Otherwise the test results workflow may attach the report to the wrong workflow