### PR TITLE
Rename tests as per SSW Rules

### DIFF
--- a/tests/Architecture.Tests/DatabaseEntitiesTest.cs
+++ b/tests/Architecture.Tests/DatabaseEntitiesTest.cs
@@ -9,7 +9,7 @@ namespace SSW.CleanArchitecture.Architecture.UnitTests;
 public class DatabaseEntities
 {
     [Fact]
-    public void Entities_Should_Inherits_BaseComponent()
+    public void Entities_ShouldInheritsBaseComponent()
     {
         var entityTypes = Types.InAssembly(typeof(DependencyInjection).Assembly)
             .That()

--- a/tests/Domain.UnitTests/TodoItems/TodoItemByTitleSpecTests.cs
+++ b/tests/Domain.UnitTests/TodoItems/TodoItemByTitleSpecTests.cs
@@ -18,7 +18,7 @@ public class TodoItemByTitleSpecTests
     [InlineData("Banana")]
     [InlineData("Apple 2")]
     [InlineData("Banana 2")]
-    public void Should_Return_ByTitle(string textToSearch)
+    public void Query_ShouldReturnByTitle(string textToSearch)
     {
         var query = new TodoItemByTitleSpec(textToSearch);
         var result = query.Evaluate(_entities).ToList();

--- a/tests/Domain.UnitTests/TodoItems/TodoItemTests.cs
+++ b/tests/Domain.UnitTests/TodoItems/TodoItemTests.cs
@@ -5,7 +5,7 @@ namespace SSW.CleanArchitecture.Domain.UnitTests.TodoItems;
 public class TodoItemTests
 {
     [Fact]
-    public void Create_Should_Succeed_When_Title_Valid()
+    public void Create_WhenTitleValid_ShouldSucceed()
     {
         // Arrange
         var title = "title";
@@ -20,7 +20,7 @@ public class TodoItemTests
     }
 
     [Fact]
-    public void Create_Should_Throw_When_Title_Null()
+    public void Create_WhenTitleNull_ShouldThrow()
     {
         // Arrange
         string? title = null;
@@ -33,7 +33,7 @@ public class TodoItemTests
     }
 
     [Fact]
-    public void Create_Should_Raise_Domain_Event()
+    public void Create_ShouldRaiseDomainEvent()
     {
         // Act
         var todoItem = TodoItem.Create("title");
@@ -45,7 +45,7 @@ public class TodoItemTests
     }
 
     [Fact]
-    public void Complete_Should_Set_Done()
+    public void Complete_ShouldSetDone()
     {
         // Arrange
         var todoItem = TodoItem.Create("title");
@@ -58,7 +58,7 @@ public class TodoItemTests
     }
 
     [Fact]
-    public void Complete_Should_Raise_Domain_Event()
+    public void Complete_ShouldRaiseDomainEvent()
     {
         // Arrange
         var todoItem = TodoItem.Create("title");

--- a/tests/WebApi.IntegrationTests/Endpoints/TodoItems/Commands/CreateTodoItem/CreateTodoItemCommandTests.cs
+++ b/tests/WebApi.IntegrationTests/Endpoints/TodoItems/Commands/CreateTodoItem/CreateTodoItemCommandTests.cs
@@ -13,7 +13,7 @@ public class CreateTodoItemCommandTests(TestingDatabaseFixture fixture, ITestOut
     : IntegrationTestBase(fixture, output)
 {
     [Fact]
-    public async Task ShouldRequireUniqueTitle()
+    public async Task Command_ShouldRequireUniqueTitle()
     {
         // Arrange
         var cmd = new CreateTodoItemCommand("Shopping");
@@ -32,7 +32,7 @@ public class CreateTodoItemCommandTests(TestingDatabaseFixture fixture, ITestOut
     }
 
     [Fact]
-    public async Task ShouldCreateTodoItem()
+    public async Task Command_ShouldCreateTodoItem()
     {
         // Arrange
         var cmd = new CreateTodoItemCommand("Shopping");

--- a/tests/WebApi.IntegrationTests/Endpoints/TodoItems/Queries/GetAllTodoItems/GetAllTodoItemsQueryTests.cs
+++ b/tests/WebApi.IntegrationTests/Endpoints/TodoItems/Queries/GetAllTodoItems/GetAllTodoItemsQueryTests.cs
@@ -10,7 +10,7 @@ public class GetAllTodoItemsQueryTests(TestingDatabaseFixture fixture, ITestOutp
     : IntegrationTestBase(fixture, output)
 {
     [Fact]
-    public async Task Should_Return_All_TodoItems()
+    public async Task Query_ShouldReturnAllTodoItems()
     {
         // Arrange
         const int entityCount = 10;


### PR DESCRIPTION
As per #207 - This PR updates the name so it follows https://www.ssw.com.au/rules/follow-naming-conventions-for-tests-and-test-projects/