### PR TITLE
♻️ Refactor constructors to use new primary constructors syntax

### DIFF
--- a/src/Application/Common/Behaviours/LoggingBehaviour.cs
+++ b/src/Application/Common/Behaviours/LoggingBehaviour.cs
@@ -4,21 +4,16 @@ using Microsoft.Extensions.Logging;
 
 namespace SSW.CleanArchitecture.Application.Common.Behaviours;
 
-public class LoggingBehaviour<TRequest> : IRequestPreProcessor<TRequest> where TRequest : notnull
+public class LoggingBehaviour<TRequest>(ILogger<TRequest> logger, ICurrentUserService currentUserService)
+    : IRequestPreProcessor<TRequest>
+    where TRequest : notnull
 {
-    private readonly ILogger _logger;
-    private readonly ICurrentUserService _currentUserService;
-
-    public LoggingBehaviour(ILogger<TRequest> logger, ICurrentUserService currentUserService)
-    {
-        _logger = logger;
-        _currentUserService = currentUserService;
-    }
+    private readonly ILogger _logger = logger;
 
     public Task Process(TRequest request, CancellationToken cancellationToken)
     {
         var requestName = typeof(TRequest).Name;
-        var userId = _currentUserService.UserId ?? string.Empty;
+        var userId = currentUserService.UserId ?? string.Empty;
 
         _logger.LogInformation("CleanArchitecture Request: {Name} {@UserId} {@Request}",
             requestName, userId, request);

--- a/src/Application/Common/Behaviours/LoggingBehaviour.cs
+++ b/src/Application/Common/Behaviours/LoggingBehaviour.cs
@@ -8,14 +8,12 @@ public class LoggingBehaviour<TRequest>(ILogger<TRequest> logger, ICurrentUserSe
     : IRequestPreProcessor<TRequest>
     where TRequest : notnull
 {
-    private readonly ILogger _logger = logger;
-
     public Task Process(TRequest request, CancellationToken cancellationToken)
     {
         var requestName = typeof(TRequest).Name;
         var userId = currentUserService.UserId ?? string.Empty;
 
-        _logger.LogInformation("CleanArchitecture Request: {Name} {@UserId} {@Request}",
+        logger.LogInformation("CleanArchitecture Request: {Name} {@UserId} {@Request}",
             requestName, userId, request);
 
         return Task.CompletedTask;

--- a/src/Application/Common/Behaviours/PerformanceBehaviour.cs
+++ b/src/Application/Common/Behaviours/PerformanceBehaviour.cs
@@ -4,21 +4,13 @@ using SSW.CleanArchitecture.Application.Common.Interfaces;
 
 namespace SSW.CleanArchitecture.Application.Common.Behaviours;
 
-public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
+public class PerformanceBehaviour<TRequest, TResponse>(
+    ILogger<TRequest> logger,
+    ICurrentUserService currentUserService)
+    : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
 {
-    private readonly Stopwatch _timer;
-    private readonly ILogger<TRequest> _logger;
-    private readonly ICurrentUserService _currentUserService;
-
-    public PerformanceBehaviour(
-        ILogger<TRequest> logger,
-        ICurrentUserService currentUserService)
-    {
-        _timer = new Stopwatch();
-
-        _logger = logger;
-        _currentUserService = currentUserService;
-    }
+    private readonly Stopwatch _timer = new();
 
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
@@ -33,9 +25,9 @@ public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequ
         if (elapsedMilliseconds > 500)
         {
             var requestName = typeof(TRequest).Name;
-            var userId = _currentUserService.UserId ?? string.Empty;
+            var userId = currentUserService.UserId ?? string.Empty;
 
-            _logger.LogWarning("CleanArchitecture Long Running Request: {Name} ({ElapsedMilliseconds} milliseconds) {@UserId} {@Request}",
+            logger.LogWarning("CleanArchitecture Long Running Request: {Name} ({ElapsedMilliseconds} milliseconds) {@UserId} {@Request}",
                 requestName, elapsedMilliseconds, userId, request);
         }
 

--- a/src/Application/Common/Behaviours/UnhandledExceptionBehaviour.cs
+++ b/src/Application/Common/Behaviours/UnhandledExceptionBehaviour.cs
@@ -2,15 +2,10 @@
 
 namespace SSW.CleanArchitecture.Application.Common.Behaviours;
 
-public class UnhandledExceptionBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
+public class UnhandledExceptionBehaviour<TRequest, TResponse>(ILogger<TRequest> logger)
+    : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
 {
-    private readonly ILogger<TRequest> _logger;
-
-    public UnhandledExceptionBehaviour(ILogger<TRequest> logger)
-    {
-        _logger = logger;
-    }
-
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         try
@@ -21,7 +16,7 @@ public class UnhandledExceptionBehaviour<TRequest, TResponse> : IPipelineBehavio
         {
             var requestName = typeof(TRequest).Name;
 
-            _logger.LogError(ex, "CleanArchitecture Request: Unhandled Exception for Request {Name} {@Request}", requestName, request);
+            logger.LogError(ex, "CleanArchitecture Request: Unhandled Exception for Request {Name} {@Request}", requestName, request);
 
             throw;
         }

--- a/src/Application/Common/Behaviours/ValidationBehaviour.cs
+++ b/src/Application/Common/Behaviours/ValidationBehaviour.cs
@@ -1,23 +1,17 @@
 ﻿namespace SSW.CleanArchitecture.Application.Common.Behaviours;
 
-public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-     where TRequest : notnull
+public class ValidationBehaviour<TRequest, TResponse>(IEnumerable<IValidator<TRequest>> validators)
+    : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
 {
-    private readonly IEnumerable<IValidator<TRequest>> _validators;
-
-    public ValidationBehaviour(IEnumerable<IValidator<TRequest>> validators)
-    {
-        _validators = validators;
-    }
-
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
-        if (_validators.Any())
+        if (validators.Any())
         {
             var context = new ValidationContext<TRequest>(request);
 
             var validationResults = await Task.WhenAll(
-                _validators.Select(v =>
+                validators.Select(v =>
                     v.ValidateAsync(context, cancellationToken)));
 
             var failures = validationResults

--- a/src/Application/Common/Exceptions/ValidationException.cs
+++ b/src/Application/Common/Exceptions/ValidationException.cs
@@ -2,14 +2,8 @@
 
 namespace SSW.CleanArchitecture.Application.Common.Exceptions;
 
-public class ValidationException : Exception
+public class ValidationException() : Exception("One or more validation failures have occurred.")
 {
-    public ValidationException()
-        : base("One or more validation failures have occurred.")
-    {
-        Errors = new Dictionary<string, string[]>();
-    }
-
     public ValidationException(IEnumerable<ValidationFailure> failures)
         : this()
     {
@@ -18,5 +12,5 @@ public class ValidationException : Exception
             .ToDictionary(failureGroup => failureGroup.Key, failureGroup => failureGroup.ToArray());
     }
 
-    public IDictionary<string, string[]> Errors { get; }
+    public IDictionary<string, string[]> Errors { get; } = new Dictionary<string, string[]>();
 }

--- a/src/Application/Features/TodoItems/Commands/CompleteTodoItem/CompleteTodoItemCommand.cs
+++ b/src/Application/Features/TodoItems/Commands/CompleteTodoItem/CompleteTodoItemCommand.cs
@@ -8,20 +8,13 @@ namespace SSW.CleanArchitecture.Application.Features.TodoItems.Commands.Complete
 public record CompleteTodoItemCommand(Guid TodoItemId) : IRequest;
 
 // ReSharper disable once UnusedType.Global
-public class CompleteTodoItemCommandHandler : IRequestHandler<CompleteTodoItemCommand>
+public class CompleteTodoItemCommandHandler(IApplicationDbContext dbContext) : IRequestHandler<CompleteTodoItemCommand>
 {
-    private readonly IApplicationDbContext _dbContext;
-
-    public CompleteTodoItemCommandHandler(IApplicationDbContext dbContext)
-    {
-        _dbContext = dbContext;
-    }
-
     public async Task Handle(CompleteTodoItemCommand request, CancellationToken cancellationToken)
     {
         var todoItemId = new TodoItemId(request.TodoItemId);
 
-        var todoItem = await _dbContext.TodoItems
+        var todoItem = await dbContext.TodoItems
             .WithSpecification(new TodoItemByIdSpec(todoItemId))
             .FirstOrDefaultAsync(cancellationToken);
 
@@ -30,6 +23,6 @@ public class CompleteTodoItemCommandHandler : IRequestHandler<CompleteTodoItemCo
 
         todoItem.Complete();
 
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/Application/Features/TodoItems/Commands/CreateTodoItem/CreateTodoItemCommand.cs
+++ b/src/Application/Features/TodoItems/Commands/CreateTodoItem/CreateTodoItemCommand.cs
@@ -6,21 +6,15 @@ namespace SSW.CleanArchitecture.Application.Features.TodoItems.Commands.CreateTo
 public record CreateTodoItemCommand(string Title) : IRequest<Guid>;
 
 // ReSharper disable once UnusedType.Global
-public class CreateTodoItemCommandHandler : IRequestHandler<CreateTodoItemCommand, Guid>
+public class CreateTodoItemCommandHandler(IApplicationDbContext dbContext)
+    : IRequestHandler<CreateTodoItemCommand, Guid>
 {
-    private readonly IApplicationDbContext _dbContext;
-
-    public CreateTodoItemCommandHandler(IApplicationDbContext dbContext)
-    {
-        _dbContext = dbContext;
-    }
-
     public async Task<Guid> Handle(CreateTodoItemCommand request, CancellationToken cancellationToken)
     {
         var todoItem = TodoItem.Create(request.Title!);
 
-        await _dbContext.TodoItems.AddAsync(todoItem, cancellationToken);
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.TodoItems.AddAsync(todoItem, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         return todoItem.Id.Value;
     }

--- a/src/Application/Features/TodoItems/EventHandlers/TodoItemCreatedEventHandler.cs
+++ b/src/Application/Features/TodoItems/EventHandlers/TodoItemCreatedEventHandler.cs
@@ -3,15 +3,12 @@ using SSW.CleanArchitecture.Domain.TodoItems;
 
 namespace SSW.CleanArchitecture.Application.Features.TodoItems.EventHandlers;
 
-public class TodoItemCreatedEventHandler : INotificationHandler<TodoItemCreatedEvent>
+public class TodoItemCreatedEventHandler(ILogger<TodoItemCreatedEventHandler> logger)
+    : INotificationHandler<TodoItemCreatedEvent>
 {
-    private readonly ILogger<TodoItemCreatedEventHandler> _logger;
-
-    public TodoItemCreatedEventHandler(ILogger<TodoItemCreatedEventHandler> logger) => _logger = logger;
-
     public Task Handle(TodoItemCreatedEvent notification, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("TodoItemCreatedEventHandler: {Title} was created", notification.Item.Title);
+        logger.LogInformation("TodoItemCreatedEventHandler: {Title} was created", notification.Item.Title);
 
         return Task.CompletedTask;
     }

--- a/src/Application/Features/TodoItems/Queries/GetAllTodoItems/GetAllTodoItemsQuery.cs
+++ b/src/Application/Features/TodoItems/Queries/GetAllTodoItems/GetAllTodoItemsQuery.cs
@@ -6,25 +6,16 @@ namespace SSW.CleanArchitecture.Application.Features.TodoItems.Queries.GetAllTod
 
 public record GetAllTodoItemsQuery : IRequest<IReadOnlyList<TodoItemDto>>;
 
-public class GetAllTodoItemsQueryHandler : IRequestHandler<GetAllTodoItemsQuery, IReadOnlyList<TodoItemDto>>
+public class GetAllTodoItemsQueryHandler(
+    IMapper mapper,
+    IApplicationDbContext dbContext) : IRequestHandler<GetAllTodoItemsQuery, IReadOnlyList<TodoItemDto>>
 {
-    private readonly IMapper _mapper;
-    private readonly IApplicationDbContext _dbContext;
-
-    public GetAllTodoItemsQueryHandler(
-        IMapper mapper,
-        IApplicationDbContext dbContext)
-    {
-        _mapper = mapper;
-        _dbContext = dbContext;
-    }
-
     public async Task<IReadOnlyList<TodoItemDto>> Handle(
         GetAllTodoItemsQuery request,
         CancellationToken cancellationToken)
     {
-        return await _dbContext.TodoItems
-            .ProjectTo<TodoItemDto>(_mapper.ConfigurationProvider)
+        return await dbContext.TodoItems
+            .ProjectTo<TodoItemDto>(mapper.ConfigurationProvider)
             .ToListAsync(cancellationToken);
     }
 }

--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -6,21 +6,12 @@ using System.Reflection;
 
 namespace SSW.CleanArchitecture.Infrastructure.Persistence;
 
-public class ApplicationDbContext : DbContext, IApplicationDbContext
+public class ApplicationDbContext(
+    DbContextOptions options,
+    EntitySaveChangesInterceptor saveChangesInterceptor,
+    DispatchDomainEventsInterceptor dispatchDomainEventsInterceptor)
+    : DbContext(options), IApplicationDbContext
 {
-    private readonly EntitySaveChangesInterceptor _saveChangesInterceptor;
-    private readonly DispatchDomainEventsInterceptor _dispatchDomainEventsInterceptor;
-
-    public ApplicationDbContext(
-        DbContextOptions options,
-        EntitySaveChangesInterceptor saveChangesInterceptor,
-        DispatchDomainEventsInterceptor dispatchDomainEventsInterceptor)
-        : base(options)
-    {
-        _saveChangesInterceptor = saveChangesInterceptor;
-        _dispatchDomainEventsInterceptor = dispatchDomainEventsInterceptor;
-    }
-
     public DbSet<TodoItem> TodoItems => Set<TodoItem>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -33,6 +24,6 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         // Order of the interceptors is important
-        optionsBuilder.AddInterceptors(_saveChangesInterceptor, _dispatchDomainEventsInterceptor);
+        optionsBuilder.AddInterceptors(saveChangesInterceptor, dispatchDomainEventsInterceptor);
     }
 }

--- a/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -5,31 +5,24 @@ using Bogus;
 
 namespace SSW.CleanArchitecture.Infrastructure.Persistence;
 
-public class ApplicationDbContextInitializer
+public class ApplicationDbContextInitializer(
+    ILogger<ApplicationDbContextInitializer> logger,
+    ApplicationDbContext dbContext)
 {
-    private readonly ILogger<ApplicationDbContextInitializer> _logger;
-    private readonly ApplicationDbContext _dbContext;
-
     private const int NumTodoItems = 20;
-
-    public ApplicationDbContextInitializer(ILogger<ApplicationDbContextInitializer> logger, ApplicationDbContext dbContext)
-    {
-        _logger = logger;
-        _dbContext = dbContext;
-    }
 
     public async Task InitializeAsync()
     {
         try
         {
-            if (_dbContext.Database.IsSqlServer())
+            if (dbContext.Database.IsSqlServer())
             {
-                await _dbContext.Database.MigrateAsync();
+                await dbContext.Database.MigrateAsync();
             }
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "An error occurred while migrating or initializing the database");
+            logger.LogError(e, "An error occurred while migrating or initializing the database");
             throw;
         }
     }
@@ -38,7 +31,7 @@ public class ApplicationDbContextInitializer
     {
         try
         {
-            if (_dbContext.TodoItems.Any())
+            if (dbContext.TodoItems.Any())
                 return;
 
             var faker = new Faker<TodoItem>()
@@ -46,12 +39,12 @@ public class ApplicationDbContextInitializer
                     f.Lorem.Sentence(3), f.Lorem.Sentence(10), f.Random.Enum<PriorityLevel>(), f.Date.Future(1, DateTime.UtcNow)));
 
             var todoItems = faker.Generate(NumTodoItems);
-            await _dbContext.TodoItems.AddRangeAsync(todoItems);
-            await _dbContext.SaveChangesAsync();
+            await dbContext.TodoItems.AddRangeAsync(todoItems);
+            await dbContext.SaveChangesAsync();
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "An error occurred while seeding the database");
+            logger.LogError(e, "An error occurred while seeding the database");
             throw;
         }
     }

--- a/src/Infrastructure/Persistence/Interceptors/DispatchDomainEventsInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/DispatchDomainEventsInterceptor.cs
@@ -5,15 +5,8 @@ using SSW.CleanArchitecture.Domain.Common.Interfaces;
 
 namespace SSW.CleanArchitecture.Infrastructure.Persistence.Interceptors;
 
-public class DispatchDomainEventsInterceptor : SaveChangesInterceptor
+public class DispatchDomainEventsInterceptor(IMediator mediator) : SaveChangesInterceptor
 {
-    private readonly IMediator _mediator;
-
-    public DispatchDomainEventsInterceptor(IMediator mediator)
-    {
-        _mediator = mediator;
-    }
-
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
         DispatchDomainEvents(eventData.Context).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -46,6 +39,6 @@ public class DispatchDomainEventsInterceptor : SaveChangesInterceptor
         entities.ForEach(e => e.ClearDomainEvents());
 
         foreach (var domainEvent in domainEvents)
-            await _mediator.Publish(domainEvent);
+            await mediator.Publish(domainEvent);
     }
 }

--- a/src/Infrastructure/Persistence/Interceptors/EntitySaveChangesInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/EntitySaveChangesInterceptor.cs
@@ -6,17 +6,9 @@ using SSW.CleanArchitecture.Domain.Common.Interfaces;
 
 namespace SSW.CleanArchitecture.Infrastructure.Persistence.Interceptors;
 
-public class EntitySaveChangesInterceptor : SaveChangesInterceptor
+public class EntitySaveChangesInterceptor(ICurrentUserService currentUserService, IDateTime dateTime)
+    : SaveChangesInterceptor
 {
-    private readonly ICurrentUserService _currentUserService;
-    private readonly IDateTime _dateTime;
-
-    public EntitySaveChangesInterceptor(ICurrentUserService currentUserService, IDateTime dateTime)
-    {
-        _currentUserService = currentUserService;
-        _dateTime = dateTime;
-    }
-
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
         UpdateEntities(eventData.Context);
@@ -39,14 +31,14 @@ public class EntitySaveChangesInterceptor : SaveChangesInterceptor
         foreach (var entry in context.ChangeTracker.Entries<IAuditableEntity>())
             if (entry.State is EntityState.Added)
             {
-                entry.Entity.CreatedAt = _dateTime.Now;
-                entry.Entity.CreatedBy = _currentUserService.UserId;
+                entry.Entity.CreatedAt = dateTime.Now;
+                entry.Entity.CreatedBy = currentUserService.UserId;
             }
             else if (entry.State is EntityState.Added or EntityState.Modified ||
                      entry.HasChangedOwnedEntities())
             {
-                entry.Entity.UpdatedAt = _dateTime.Now;
-                entry.Entity.UpdatedBy = _currentUserService.UserId;
+                entry.Entity.UpdatedAt = dateTime.Now;
+                entry.Entity.UpdatedBy = currentUserService.UserId;
             }
     }
 }

--- a/src/WebApi/HealthChecks/EntityFrameworkDbContextHealthCheck/EntityFrameworkDbContextHealthCheck.cs
+++ b/src/WebApi/HealthChecks/EntityFrameworkDbContextHealthCheck/EntityFrameworkDbContextHealthCheck.cs
@@ -4,16 +4,14 @@ using Microsoft.Extensions.Options;
 
 namespace SSW.CleanArchitecture.WebApi.HealthChecks.EntityFrameworkDbContextHealthCheck;
 
-public sealed class EntityFrameworkDbContextHealthCheck<TContext> : IHealthCheck where TContext : DbContext
+public sealed class EntityFrameworkDbContextHealthCheck<TContext>(
+    TContext dbContext,
+    IOptionsMonitor<EntityFrameworkDbContextHealthCheckOptions<TContext>> options)
+    : IHealthCheck
+    where TContext : DbContext
 {
-    private readonly TContext _dbContext;
-    private readonly IOptionsMonitor<EntityFrameworkDbContextHealthCheckOptions<TContext>> _options;
-
-    public EntityFrameworkDbContextHealthCheck(TContext dbContext, IOptionsMonitor<EntityFrameworkDbContextHealthCheckOptions<TContext>> options)
-    {
-        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
-        _options = options ?? throw new ArgumentNullException(nameof(options));
-    }
+    private readonly TContext _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    private readonly IOptionsMonitor<EntityFrameworkDbContextHealthCheckOptions<TContext>> _options = options ?? throw new ArgumentNullException(nameof(options));
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {

--- a/src/WebApi/Services/CurrentUserService.cs
+++ b/src/WebApi/Services/CurrentUserService.cs
@@ -3,11 +3,7 @@ using System.Security.Claims;
 
 namespace SSW.CleanArchitecture.WebApi.Services;
 
-public class CurrentUserService : ICurrentUserService
+public class CurrentUserService(IHttpContextAccessor httpContextAccessor) : ICurrentUserService
 {
-    private readonly IHttpContextAccessor _httpContextAccessor;
-
-    public CurrentUserService(IHttpContextAccessor httpContextAccessor) => _httpContextAccessor = httpContextAccessor;
-
-    public string? UserId => _httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+    public string? UserId => httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
 }


### PR DESCRIPTION
Constructors for a several classes across the project have been refactored to take advantage of shortcut syntax. The changes reduce the amount of boilerplate code and increase readability. This also brings the code in line with modern conventions.