### PR TITLE
♻️ Remove DateTimeService and IDateTime interface

### DIFF
--- a/src/Application/Common/Interfaces/IDateTime.cs
+++ b/src/Application/Common/Interfaces/IDateTime.cs
@@ -1,7 +1,0 @@
-﻿namespace SSW.CleanArchitecture.Application.Common.Interfaces;
-
-public interface IDateTime
-{
-    // TODO: Talk to Gordon about this - System Clock (https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/77)
-    public DateTimeOffset Now => DateTimeOffset.UtcNow;
-}

--- a/src/Application/Features/TodoItems/Commands/CompleteTodoItem/CompleteTodoItemCommand.cs
+++ b/src/Application/Features/TodoItems/Commands/CompleteTodoItem/CompleteTodoItemCommand.cs
@@ -8,7 +8,8 @@ namespace SSW.CleanArchitecture.Application.Features.TodoItems.Commands.Complete
 public record CompleteTodoItemCommand(Guid TodoItemId) : IRequest;
 
 // ReSharper disable once UnusedType.Global
-public class CompleteTodoItemCommandHandler(IApplicationDbContext dbContext) : IRequestHandler<CompleteTodoItemCommand>
+public class CompleteTodoItemCommandHandler(IApplicationDbContext dbContext)
+    : IRequestHandler<CompleteTodoItemCommand>
 {
     public async Task Handle(CompleteTodoItemCommand request, CancellationToken cancellationToken)
     {

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 using SSW.CleanArchitecture.Application.Common.Interfaces;
 using SSW.CleanArchitecture.Infrastructure.Persistence;
 using SSW.CleanArchitecture.Infrastructure.Persistence.Interceptors;
-using SSW.CleanArchitecture.Infrastructure.Services;
 
 namespace SSW.CleanArchitecture.Infrastructure;
 
@@ -24,7 +23,7 @@ public static class DependencyInjection
 
         services.AddScoped<ApplicationDbContextInitializer>();
 
-        services.AddSingleton<IDateTime, DateTimeService>();
+        services.AddSingleton(TimeProvider.System);
 
         return services;
     }

--- a/src/Infrastructure/Persistence/Interceptors/EntitySaveChangesInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/EntitySaveChangesInterceptor.cs
@@ -6,7 +6,7 @@ using SSW.CleanArchitecture.Domain.Common.Interfaces;
 
 namespace SSW.CleanArchitecture.Infrastructure.Persistence.Interceptors;
 
-public class EntitySaveChangesInterceptor(ICurrentUserService currentUserService, IDateTime dateTime)
+public class EntitySaveChangesInterceptor(ICurrentUserService currentUserService, TimeProvider timeProvider)
     : SaveChangesInterceptor
 {
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
@@ -31,13 +31,13 @@ public class EntitySaveChangesInterceptor(ICurrentUserService currentUserService
         foreach (var entry in context.ChangeTracker.Entries<IAuditableEntity>())
             if (entry.State is EntityState.Added)
             {
-                entry.Entity.CreatedAt = dateTime.Now;
+                entry.Entity.CreatedAt = timeProvider.GetUtcNow();
                 entry.Entity.CreatedBy = currentUserService.UserId;
             }
             else if (entry.State is EntityState.Added or EntityState.Modified ||
                      entry.HasChangedOwnedEntities())
             {
-                entry.Entity.UpdatedAt = dateTime.Now;
+                entry.Entity.UpdatedAt = timeProvider.GetUtcNow();
                 entry.Entity.UpdatedBy = currentUserService.UserId;
             }
     }

--- a/src/Infrastructure/Services/DateTimeService.cs
+++ b/src/Infrastructure/Services/DateTimeService.cs
@@ -1,5 +1,0 @@
-﻿using SSW.CleanArchitecture.Application.Common.Interfaces;
-
-namespace SSW.CleanArchitecture.Infrastructure.Services;
-
-public class DateTimeService : IDateTime { }


### PR DESCRIPTION
The DateTimeService class and IDateTime interface have been deleted as they were unnecessary. In their place, the TimeProvider.System has been utilized for more efficient time management. All the dependencies have been updated accordingly, including the EntitySaveChangesInterceptor class and the dependency injection setup.