### PR TITLE
♻️ Updated order of the project in sln to make WebApi startup project by default

### DIFF
--- a/SSW.CleanArchitecture.sln
+++ b/SSW.CleanArchitecture.sln
@@ -3,13 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi", "src\WebApi\WebApi.csproj", "{2881AC5A-3E80-4AF5-AC2B-A2C884CD12F6}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Domain", "src\Domain\Domain.csproj", "{8D70033C-CE63-4A79-B39C-C1E8F63D304F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Application", "src\Application\Application.csproj", "{39F18333-2540-48D7-B98C-CD647FF4570F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Infrastructure", "src\Infrastructure\Infrastructure.csproj", "{CC3ECFD4-1BD5-4DAD-804C-C15C6CD4B16E}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi", "src\WebApi\WebApi.csproj", "{2881AC5A-3E80-4AF5-AC2B-A2C884CD12F6}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EF950CC1-632F-4015-A12A-83046B14B99A}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
This will make the WebApi project the default startup project.

To test this in Visual Studio, delete `.vs` and run Visual Studio.

![image](https://github.com/SSWConsulting/SSW.CleanArchitecture/assets/5943653/4498197c-ad73-4e10-b588-b1c626d97e13)

![image](https://github.com/SSWConsulting/SSW.CleanArchitecture/assets/5943653/945fa3f5-477b-43ca-91cf-57197a59d8fc)