### PR TITLE
✨ Source generate the ApplicationDbContext implementations

### DIFF
--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="GeneratedEntityFramework" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using GeneratedEntityFramework;
+using Microsoft.EntityFrameworkCore;
 using SSW.CleanArchitecture.Application.Common.Interfaces;
 using SSW.CleanArchitecture.Domain.TodoItems;
 using SSW.CleanArchitecture.Infrastructure.Persistence.Interceptors;
@@ -6,14 +7,13 @@ using System.Reflection;
 
 namespace SSW.CleanArchitecture.Infrastructure.Persistence;
 
-public class ApplicationDbContext(
+[GeneratedDbContext]
+public partial class ApplicationDbContext(
     DbContextOptions options,
     EntitySaveChangesInterceptor saveChangesInterceptor,
     DispatchDomainEventsInterceptor dispatchDomainEventsInterceptor)
     : DbContext(options), IApplicationDbContext
 {
-    public DbSet<TodoItem> TodoItems => Set<TodoItem>();
-
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());


### PR DESCRIPTION
When dealing with Entity Framework in the context of a Clean Architecture application, over time, as the number of DbSets increase, the constant back and forth between the interface and the implementation can become rather tedious and is subject to implementations being left in the DbContext which are no longer used by the interface.

I wrote a source generator that will generate the implementations as a partial of the DbContext based on the properties of the interface: https://github.com/jscarle/GeneratedEntityFramework

This pull request removes the `TodoItems` DbSet implementation from the `ApplicationDbContext` and replaces it with the source generated implementation.