### PR TITLE
👷‍♂️ 306  move seed data and migrations out of api

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,16 @@ dotnet new ssw-ca-command --name {{CommandName}} --entityName {{Entity}} --slnNa
 
 ### Running the Solution
 
-1. Start dockerized SQL Server
+1. Start dockerized SQL Server, create and seed the database.
 
+Windows:
+```ps
+.\up.ps1
+```
+
+Mac/Linux:
 ```bash
-docker compose up
+pwsh ./up.ps1
 ```
 
 2. Run the solution

--- a/SSW.CleanArchitecture.sln
+++ b/SSW.CleanArchitecture.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		docker-compose.yml = docker-compose.yml
 		global.json = global.json
 		README.md = README.md
+		up.ps1 = up.ps1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A388D69B-2789-4D2E-A6D9-331D8571DA7E}"
@@ -33,6 +34,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Domain.UnitTests", "tests\Domain.UnitTests\Domain.UnitTests.csproj", "{E631C496-2285-4B0E-8C04-EB9D0766D01A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi.IntegrationTests", "tests\WebApi.IntegrationTests\WebApi.IntegrationTests.csproj", "{6FAECF07-C024-45F6-B78A-A2771833F867}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{7AFFF91C-498F-4CE9-9DCB-E2FDBA18E81A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Database", "tools\Database\Database.csproj", "{08A4FCE5-D49A-4FC1-BB0B-3206326157BD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -68,6 +73,10 @@ Global
 		{6FAECF07-C024-45F6-B78A-A2771833F867}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6FAECF07-C024-45F6-B78A-A2771833F867}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6FAECF07-C024-45F6-B78A-A2771833F867}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08A4FCE5-D49A-4FC1-BB0B-3206326157BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08A4FCE5-D49A-4FC1-BB0B-3206326157BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08A4FCE5-D49A-4FC1-BB0B-3206326157BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08A4FCE5-D49A-4FC1-BB0B-3206326157BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -80,6 +89,7 @@ Global
 		{526EDF1F-026F-41EC-9FC5-433243492515} = {A388D69B-2789-4D2E-A6D9-331D8571DA7E}
 		{E631C496-2285-4B0E-8C04-EB9D0766D01A} = {A388D69B-2789-4D2E-A6D9-331D8571DA7E}
 		{6FAECF07-C024-45F6-B78A-A2771833F867} = {A388D69B-2789-4D2E-A6D9-331D8571DA7E}
+		{08A4FCE5-D49A-4FC1-BB0B-3206326157BD} = {7AFFF91C-498F-4CE9-9DCB-E2FDBA18E81A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8975F724-46D1-4802-8C4B-6B386B69846F}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -15,13 +15,18 @@ public static class DependencyInjection
         services.AddScoped<DispatchDomainEventsInterceptor>();
 
         services.AddDbContext<IApplicationDbContext, ApplicationDbContext>(options =>
+        {
+            options.AddInterceptors(
+                services.BuildServiceProvider().GetRequiredService<EntitySaveChangesInterceptor>(),
+                services.BuildServiceProvider().GetRequiredService<DispatchDomainEventsInterceptor>()
+            );
+
             options.UseSqlServer(config.GetConnectionString("DefaultConnection"), builder =>
             {
                 builder.MigrationsAssembly(typeof(DependencyInjection).Assembly.FullName);
                 builder.EnableRetryOnFailure();
-            }));
-
-        services.AddScoped<ApplicationDbContextInitializer>();
+            });
+        });
 
         services.AddSingleton(TimeProvider.System);
 

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -11,7 +11,6 @@
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -11,9 +11,7 @@ using System.Reflection;
 namespace SSW.CleanArchitecture.Infrastructure.Persistence;
 
 public class ApplicationDbContext(
-    DbContextOptions options,
-    EntitySaveChangesInterceptor saveChangesInterceptor,
-    DispatchDomainEventsInterceptor dispatchDomainEventsInterceptor)
+    DbContextOptions options)
     : DbContext(options), IApplicationDbContext
 {
     public DbSet<TodoItem> TodoItems => Set<TodoItem>();
@@ -27,12 +25,6 @@ public class ApplicationDbContext(
         modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
 
         base.OnModelCreating(modelBuilder);
-    }
-
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-        // Order of the interceptors is important
-        optionsBuilder.AddInterceptors(saveChangesInterceptor, dispatchDomainEventsInterceptor);
     }
 
     private DbSet<T> AggregateRootSet<T>() where T : class, IAggregateRoot => Set<T>();

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -19,12 +19,6 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseDeveloperExceptionPage();
-
-    // Initialise and seed database
-    using var scope = app.Services.CreateScope();
-    var initializer = scope.ServiceProvider.GetRequiredService<ApplicationDbContextInitializer>();
-    await initializer.InitializeAsync();
-    await initializer.SeedAsync();
 }
 else
 {

--- a/tests/WebApi.IntegrationTests/Common/Fixtures/IntegrationTestWebApplicationFactory.cs
+++ b/tests/WebApi.IntegrationTests/Common/Fixtures/IntegrationTestWebApplicationFactory.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using SSW.CleanArchitecture.Database;
 using SSW.CleanArchitecture.Infrastructure.Persistence;
 
 namespace WebApi.IntegrationTests.Common.Fixtures;
@@ -33,6 +34,10 @@ public class WebApiTestFactory : WebApplicationFactory<Program>
         });
 
         // Override default DB registration to use out Test Container instead
-        builder.ConfigureTestServices(services => services.ReplaceDbContext<ApplicationDbContext>(Database));
+        builder.ConfigureTestServices(services =>
+        {
+            services.ReplaceDbContext<ApplicationDbContext>(Database);
+            services.AddScoped<ApplicationDbContextInitializer>();
+        });
     }
 }

--- a/tests/WebApi.IntegrationTests/Common/Fixtures/ServiceCollectionExt.cs
+++ b/tests/WebApi.IntegrationTests/Common/Fixtures/ServiceCollectionExt.cs
@@ -25,7 +25,6 @@ internal static class ServiceCollectionExt
 
                 options.AddInterceptors(
                     services.BuildServiceProvider().GetRequiredService<EntitySaveChangesInterceptor>()
-                    //services.BuildServiceProvider().GetRequiredService<DispatchDomainEventsInterceptor>()
                 );
             });
 

--- a/tests/WebApi.IntegrationTests/Common/Fixtures/ServiceCollectionExt.cs
+++ b/tests/WebApi.IntegrationTests/Common/Fixtures/ServiceCollectionExt.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using SSW.CleanArchitecture.Infrastructure.Persistence.Interceptors;
 
 namespace WebApi.IntegrationTests.Common.Fixtures;
 
@@ -9,15 +11,23 @@ internal static class ServiceCollectionExt
     /// <summary>
     /// Replaces the DbContext with a new instance using the provided database container
     /// </summary>
-    internal static IServiceCollection ReplaceDbContext<T>(this IServiceCollection services,
+    internal static IServiceCollection ReplaceDbContext<T>(
+        this IServiceCollection services,
         DatabaseContainer databaseContainer) where T : DbContext
     {
         services
             .RemoveAll<DbContextOptions<T>>()
             .RemoveAll<T>()
             .AddDbContext<T>((_, options) =>
+            {
                 options.UseSqlServer(databaseContainer.ConnectionString,
-                    b => b.MigrationsAssembly(typeof(T).Assembly.FullName)));
+                    b => b.MigrationsAssembly(typeof(T).Assembly.FullName));
+
+                options.AddInterceptors(
+                    services.BuildServiceProvider().GetRequiredService<EntitySaveChangesInterceptor>()
+                    //services.BuildServiceProvider().GetRequiredService<DispatchDomainEventsInterceptor>()
+                );
+            });
 
         return services;
     }

--- a/tests/WebApi.IntegrationTests/Common/Fixtures/TestingDatabaseFixture.cs
+++ b/tests/WebApi.IntegrationTests/Common/Fixtures/TestingDatabaseFixture.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Respawn;
+using SSW.CleanArchitecture.Database;
 
 namespace WebApi.IntegrationTests.Common.Fixtures;
 
@@ -19,8 +20,15 @@ public class TestingDatabaseFixture : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        // Initialize DB Container
         await Factory.Database.InitializeAsync();
         ScopeFactory = Factory.Services.GetRequiredService<IServiceScopeFactory>();
+
+        // Create and seed database
+        using var scope = ScopeFactory.CreateScope();
+        var initializer = scope.ServiceProvider.GetRequiredService<ApplicationDbContextInitializer>();
+        await initializer.InitializeAsync();
+        // await initializer.SeedAsync();
 
         // NOTE: If there are any tables you want to skip being reset, they can be configured here
         _checkpoint = await Respawner.CreateAsync(ConnectionString);

--- a/tests/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/tests/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\WebApi\WebApi.csproj" />
+    <ProjectReference Include="..\..\tools\Database\Database.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/Database/ApplicationDbContextInitializer.cs
+++ b/tools/Database/ApplicationDbContextInitializer.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Bogus;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using SSW.CleanArchitecture.Domain.TodoItems;
-using Bogus;
 using SSW.CleanArchitecture.Domain.Heroes;
 using SSW.CleanArchitecture.Domain.Teams;
+using SSW.CleanArchitecture.Infrastructure.Persistence;
 
-namespace SSW.CleanArchitecture.Infrastructure.Persistence;
+namespace Database;
 
 public class ApplicationDbContextInitializer(
     ILogger<ApplicationDbContextInitializer> logger,
@@ -93,7 +93,6 @@ public class ApplicationDbContextInitializer(
             throw;
         }
     }
-
 
     private async Task<List<Hero>> SeedHeroes()
     {

--- a/tools/Database/ApplicationDbContextInitializer.cs
+++ b/tools/Database/ApplicationDbContextInitializer.cs
@@ -43,15 +43,6 @@ public class ApplicationDbContextInitializer(
         "Intelligence"
     ];
 
-    private readonly string[] _teamNames =
-    [
-        "Marvel",
-        "Avengers",
-        "DC",
-        "Justice League",
-        "X-Men"
-    ];
-
     private readonly string[] _missionNames =
     [
         "Save the world",
@@ -61,7 +52,17 @@ public class ApplicationDbContextInitializer(
         "Protect the city"
     ];
 
-    private const int NumHeroes = 20;
+    private readonly string[] _teamNames =
+    [
+        "Marvel",
+        "Avengers",
+        "DC",
+        "Justice League",
+        "X-Men"
+    ];
+
+    private const int NumHeroes = 1000;
+
     private const int NumTeams = 5;
 
     public async Task InitializeAsync()

--- a/tools/Database/ApplicationDbContextInitializer.cs
+++ b/tools/Database/ApplicationDbContextInitializer.cs
@@ -5,7 +5,7 @@ using SSW.CleanArchitecture.Domain.Heroes;
 using SSW.CleanArchitecture.Domain.Teams;
 using SSW.CleanArchitecture.Infrastructure.Persistence;
 
-namespace Database;
+namespace SSW.CleanArchitecture.Database;
 
 public class ApplicationDbContextInitializer(
     ILogger<ApplicationDbContextInitializer> logger,
@@ -61,7 +61,7 @@ public class ApplicationDbContextInitializer(
         "X-Men"
     ];
 
-    private const int NumHeroes = 1000;
+    private const int NumHeroes = 20;
 
     private const int NumTeams = 5;
 

--- a/tools/Database/Database.csproj
+++ b/tools/Database/Database.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>SSW.CleanArchitecture.Database</RootNamespace>
+    <AssemblyName>SSW.CleanArchitecture.Database</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tools/Database/Database.csproj
+++ b/tools/Database/Database.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Infrastructure\Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Bogus" Version="34.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="appsettings.json" />
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/tools/Database/Program.cs
+++ b/tools/Database/Program.cs
@@ -1,0 +1,32 @@
+﻿using Database;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SSW.CleanArchitecture.Application.Common.Interfaces;
+using SSW.CleanArchitecture.Infrastructure;
+using SSW.CleanArchitecture.Infrastructure.Persistence;
+
+var builder = Host.CreateDefaultBuilder(args);
+
+builder.ConfigureServices((context, services) =>
+{
+    var connection = context.Configuration.GetConnectionString("DefaultConnection");
+
+    services.AddDbContext<ApplicationDbContext>(options =>
+        options.UseSqlServer(context.Configuration.GetConnectionString("DefaultConnection"), opt =>
+        {
+            opt.MigrationsAssembly(typeof(DependencyInjection).Assembly.FullName);
+        }));
+
+    services.AddScoped<ApplicationDbContextInitializer>();
+});
+
+var app = builder.Build();
+app.Start();
+
+// Initialise and seed database
+using var scope = app.Services.CreateScope();
+var initializer = scope.ServiceProvider.GetRequiredService<ApplicationDbContextInitializer>();
+await initializer.InitializeAsync();
+await initializer.SeedAsync();

--- a/tools/Database/Program.cs
+++ b/tools/Database/Program.cs
@@ -1,9 +1,9 @@
-﻿using Database;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SSW.CleanArchitecture.Application.Common.Interfaces;
+using SSW.CleanArchitecture.Database;
 using SSW.CleanArchitecture.Infrastructure;
 using SSW.CleanArchitecture.Infrastructure.Persistence;
 

--- a/tools/Database/Program.cs
+++ b/tools/Database/Program.cs
@@ -6,6 +6,7 @@ using SSW.CleanArchitecture.Application.Common.Interfaces;
 using SSW.CleanArchitecture.Database;
 using SSW.CleanArchitecture.Infrastructure;
 using SSW.CleanArchitecture.Infrastructure.Persistence;
+using SSW.CleanArchitecture.Infrastructure.Persistence.Interceptors;
 
 var builder = Host.CreateDefaultBuilder(args);
 
@@ -14,10 +15,15 @@ builder.ConfigureServices((context, services) =>
     var connection = context.Configuration.GetConnectionString("DefaultConnection");
 
     services.AddDbContext<ApplicationDbContext>(options =>
+    {
         options.UseSqlServer(context.Configuration.GetConnectionString("DefaultConnection"), opt =>
         {
             opt.MigrationsAssembly(typeof(DependencyInjection).Assembly.FullName);
-        }));
+        });
+
+        options.AddInterceptors(services.BuildServiceProvider().GetRequiredService<EntitySaveChangesInterceptor>());
+    });
+
 
     services.AddScoped<ApplicationDbContextInitializer>();
 });

--- a/tools/Database/Program.cs
+++ b/tools/Database/Program.cs
@@ -12,8 +12,6 @@ var builder = Host.CreateDefaultBuilder(args);
 
 builder.ConfigureServices((context, services) =>
 {
-    var connection = context.Configuration.GetConnectionString("DefaultConnection");
-
     services.AddDbContext<ApplicationDbContext>(options =>
     {
         options.UseSqlServer(context.Configuration.GetConnectionString("DefaultConnection"), opt =>

--- a/tools/Database/appsettings.json
+++ b/tools/Database/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost,1433;Initial Catalog=CleanArchitecture;Persist Security Info=False;User ID=sa;Password=yourStrong(!)Password;MultipleActiveResultSets=True;TrustServerCertificate=True;Connection Timeout=30;"
+  }
+}

--- a/up.ps1
+++ b/up.ps1
@@ -1,42 +1,16 @@
-Write-Host "🚢 Starting Docker Compose"
+Param(
+    [switch]$skipDeploy = $false
+)
+
+Write-Host "🚢 Starting Docker Compose" -ForegroundColor Green
 docker compose up -d
 
-Write-Host "🚀 Creating and Seeding Database"
-Set-Location ./tools/Database/
-dotnet run
+if (-not $skipDeploy) {
+    $upScriptPath = $Script:MyInvocation.MyCommand.Path | Split-Path
 
-#
-#Param(
-#[switch]$skipDeploy = $false,
-#[switch]$linux = $false
-#)
-#
+    Write-Host "🚀 Creating and Seeding Database" -ForegroundColor Green
+    Set-Location ./tools/Database/
+    dotnet run
 
-#if (-not $skipDeploy) {
-#
-#    Write-Host "⚙️ Restore dotnet tools"
-#    dotnet tool restore
-#
-#    Set-Location $($Script:MyInvocation.MyCommand.Path | Split-Path)
-#
-#    if ($linux) {
-#        Write-Host "⚙️ Building GordonBeemingCom Database AppDbContext Bundle"
-#        dotnet restore --runtime 'linux-x64'
-#        Set-Location ./src/
-#        dotnet ef migrations bundle --project 'GordonBeemingCom.Database' --startup-project 'GordonBeemingCom' --force --context AppDbContext --output AppDbContextEfBundle
-#
-#        Write-Host "🚀 Deploying GordonBeemingCom Database AppDbContext Bundle"
-#        . ./AppDbContextEfBundle --connection "Server=.,1600;Database=GordonBeemingCom;User Id=sa;Password=Password!@2;MultipleActiveResultSets=true;TrustServerCertificate=True;"
-#    }
-#    else {
-#        Write-Host "⚙️ Building GordonBeemingCom Database AppDbContext Bundle"
-#        dotnet restore --runtime 'win-x64'
-#        Set-Location .\src\
-#        dotnet ef migrations bundle --project 'GordonBeemingCom.Database' --startup-project 'GordonBeemingCom' --force --context AppDbContext --output AppDbContextEfBundle.exe
-#
-#        Write-Host "🚀 Deploying GordonBeemingCom Database AppDbContext Bundle"
-#        . .\AppDbContextEfBundle.exe --connection "Server=.,1600;Database=GordonBeemingCom;User Id=sa;Password=Password!@2;MultipleActiveResultSets=true;TrustServerCertificate=True;"
-#    }
-#
-#    Set-Location $($Script:MyInvocation.MyCommand.Path | Split-Path)
-#}
+    Set-Location $upScriptPath
+}

--- a/up.ps1
+++ b/up.ps1
@@ -1,0 +1,42 @@
+Write-Host "🚢 Starting Docker Compose"
+docker compose up -d
+
+Write-Host "🚀 Creating and Seeding Database"
+Set-Location ./tools/Database/
+dotnet run
+
+#
+#Param(
+#[switch]$skipDeploy = $false,
+#[switch]$linux = $false
+#)
+#
+
+#if (-not $skipDeploy) {
+#
+#    Write-Host "⚙️ Restore dotnet tools"
+#    dotnet tool restore
+#
+#    Set-Location $($Script:MyInvocation.MyCommand.Path | Split-Path)
+#
+#    if ($linux) {
+#        Write-Host "⚙️ Building GordonBeemingCom Database AppDbContext Bundle"
+#        dotnet restore --runtime 'linux-x64'
+#        Set-Location ./src/
+#        dotnet ef migrations bundle --project 'GordonBeemingCom.Database' --startup-project 'GordonBeemingCom' --force --context AppDbContext --output AppDbContextEfBundle
+#
+#        Write-Host "🚀 Deploying GordonBeemingCom Database AppDbContext Bundle"
+#        . ./AppDbContextEfBundle --connection "Server=.,1600;Database=GordonBeemingCom;User Id=sa;Password=Password!@2;MultipleActiveResultSets=true;TrustServerCertificate=True;"
+#    }
+#    else {
+#        Write-Host "⚙️ Building GordonBeemingCom Database AppDbContext Bundle"
+#        dotnet restore --runtime 'win-x64'
+#        Set-Location .\src\
+#        dotnet ef migrations bundle --project 'GordonBeemingCom.Database' --startup-project 'GordonBeemingCom' --force --context AppDbContext --output AppDbContextEfBundle.exe
+#
+#        Write-Host "🚀 Deploying GordonBeemingCom Database AppDbContext Bundle"
+#        . .\AppDbContextEfBundle.exe --connection "Server=.,1600;Database=GordonBeemingCom;User Id=sa;Password=Password!@2;MultipleActiveResultSets=true;TrustServerCertificate=True;"
+#    }
+#
+#    Set-Location $($Script:MyInvocation.MyCommand.Path | Split-Path)
+#}


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #294 

> 2. What was changed?

✏️ Previously DB creation and data seeding was done in `Program.cs` in Development mode.  There is risk that this might be run on PROD which isn't great.P

Migrated DB migrations and seeding to a new project under `Tools\Database`.  This project is then called by `up.ps1` to handle creation of SQL Server, DB, and Seed data all in one command.

> 3. Did you do pair or mob programming?

✏️ Yes with @william-liebenberg 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
