### PR TITLE
✨ Added command to drop database on demand

### DIFF
--- a/tools/AppHost/AppHost.csproj
+++ b/tools/AppHost/AppHost.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0-rc.1.24511.1"/>
     <PackageReference Include="Aspire.Hosting.SqlServer" Version="9.0.0-rc.1.24511.1"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-rc.2.24474.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/AppHost/Commands/SqlServerCommandExt.cs
+++ b/tools/AppHost/Commands/SqlServerCommandExt.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace AppHost.Commands;
+
+public static class SqlServerCommandExt
+{
+    public static IResourceBuilder<SqlServerServerResource> WithDropDatabaseCommand(
+        this IResourceBuilder<SqlServerServerResource> builder)
+    {
+        builder.WithCommand(
+            "drop-database",
+            "Drop Database",
+            async context =>
+            {
+                var connectionString = await builder.Resource.GetConnectionStringAsync();
+                ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+                var optionsBuilder = new DbContextOptionsBuilder<DbContext>();
+                optionsBuilder.UseSqlServer(connectionString);
+                var db = new DbContext(optionsBuilder.Options);
+                await db.Database.EnsureDeletedAsync();
+
+                return CommandResults.Success();
+            },
+            context =>
+            {
+                if (context.ResourceSnapshot.HealthStatus is HealthStatus.Healthy)
+                {
+                    return ResourceCommandState.Enabled;
+                }
+
+                return ResourceCommandState.Disabled;
+            });
+        return builder;
+    }
+}

--- a/tools/AppHost/Program.cs
+++ b/tools/AppHost/Program.cs
@@ -1,3 +1,4 @@
+using AppHost.Commands;
 using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -5,6 +6,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 // Ensure the port doesn't conflict with other docker containers (or remove it altogether)
 var sqlServer = builder
     .AddSqlServer("sql", port: 1800)
+    .WithDropDatabaseCommand()
     .WithLifetime(ContainerLifetime.Persistent);
 
 var db = sqlServer

--- a/tools/MigrationService/Initializers/DbContextInitializerBase.cs
+++ b/tools/MigrationService/Initializers/DbContextInitializerBase.cs
@@ -21,10 +21,10 @@ public abstract class DbContextInitializerBase<T> where T : DbContext
         var strategy = DbContext.Database.CreateExecutionStrategy();
         await strategy.ExecuteAsync(async () =>
         {
+            // Create the database if it does not exist.
+            // Do this first so there is then a database to start a transaction against.
             if (!await dbCreator.ExistsAsync(cancellationToken))
             {
-                // Create the database if it does not exist.
-                // Do this first so there is then a database to start a transaction against.
                 await dbCreator.CreateAsync(cancellationToken);
             }
         });


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/410

> 2. What was changed?

✏️ Added command to drop database on demand. This is useful when not using migrations and the DB schema needs to be recreated. With this command we can now drop the db and re-run the migration service without making changes to our code.

![image](https://github.com/user-attachments/assets/de65ba17-f383-408a-b729-d6a7557fe91e)

> 3. Did you do pair or mob programming?

✏️ No