### PR TITLE
✨ Show example of using ErrorOr in a query

### DIFF
--- a/src/Application/UseCases/Teams/Queries/GetTeam/GetTeamQuery.cs
+++ b/src/Application/UseCases/Teams/Queries/GetTeam/GetTeamQuery.cs
@@ -3,11 +3,11 @@ using SSW.CleanArchitecture.Domain.Teams;
 
 namespace SSW.CleanArchitecture.Application.UseCases.Teams.Queries.GetTeam;
 
-public record GetTeamQuery(Guid TeamId) : IRequest<TeamDto?>;
+public record GetTeamQuery(Guid TeamId) : IRequest<ErrorOr<TeamDto>>;
 
-public sealed class GetAllTeamsQueryHandler(IApplicationDbContext dbContext) : IRequestHandler<GetTeamQuery, TeamDto?>
+public sealed class GetAllTeamsQueryHandler(IApplicationDbContext dbContext) : IRequestHandler<GetTeamQuery, ErrorOr<TeamDto>>
 {
-    public async Task<TeamDto?> Handle(
+    public async Task<ErrorOr<TeamDto>> Handle(
         GetTeamQuery request,
         CancellationToken cancellationToken)
     {
@@ -22,6 +22,9 @@ public sealed class GetAllTeamsQueryHandler(IApplicationDbContext dbContext) : I
                 Heroes = t.Heroes.Select(h => new HeroDto { Id = h.Id.Value, Name = h.Name }).ToList()
             })
             .FirstOrDefaultAsync(cancellationToken);
+
+        if (team is null)
+            return TeamErrors.NotFound;
 
         return team;
     }


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/425

> 2. What was changed?

✏️ 
This pull request includes changes to the `GetTeamQuery` and `GetAllTeamsQueryHandler` to improve error handling in the `GetTeam` use case.

Error handling improvements:

* [`src/Application/UseCases/Teams/Queries/GetTeam/GetTeamQuery.cs`](diffhunk://#diff-3fbc5e7658ae01783b013a3e11f46cbfaac9ead368136a94c47d09fc19b5195fL6-R10): Updated the `GetTeamQuery` to return `ErrorOr<TeamDto>` instead of `TeamDto?` to better handle errors.
* [`src/Application/UseCases/Teams/Queries/GetTeam/GetTeamQuery.cs`](diffhunk://#diff-3fbc5e7658ae01783b013a3e11f46cbfaac9ead368136a94c47d09fc19b5195fR26-R28): Modified the `GetAllTeamsQueryHandler` to return `ErrorOr<TeamDto>` and added a check to return a `NotFound` error if the team is not found.

> 3. Did you do pair or mob programming?

✏️ No