### PR TITLE
📦 433 net 9 upgrade

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.2",
+    "version": "9.0.100",
     "rollForward": "latestFeature",
-    "allowPrerelease": true
+    "allowPrerelease": false
   }
 }

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="ErrorOr" Version="2.0.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-rc.2.24474.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0-rc.2.24473.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -13,11 +13,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
     
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-rc.1.24511.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0-preview.9.24507.7" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0-rc.1.24511.1"/>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0"/>
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0"/>
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+    
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0"/>
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0"/>
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0"/>

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -14,15 +14,11 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
-    <!-- Need to explictly reference Azure.Identity to remove vulnerability as Respawn uses a vulnerable version -->
-<!--    <PackageReference Include="Azure.Identity" Version="1.13.0" />-->
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-<!--    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.0-rc.2.24474.3" />-->
-<!--    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.0-rc.2.24474.3" />-->
     <PackageReference Include="Scalar.AspNetCore" Version="1.2.35" />
   </ItemGroup>
 

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -15,15 +15,15 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <!-- Need to explictly reference Azure.Identity to remove vulnerability as Respawn uses a vulnerable version -->
-    <PackageReference Include="Azure.Identity" Version="1.13.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.2.24474.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-rc.2.24474.1">
+<!--    <PackageReference Include="Azure.Identity" Version="1.13.0" />-->
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.0-rc.2.24474.3" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.0-rc.2.24474.3" />
-    <PackageReference Include="Scalar.AspNetCore" Version="1.2.21" />
+<!--    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.0-rc.2.24474.3" />-->
+<!--    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.0-rc.2.24474.3" />-->
+    <PackageReference Include="Scalar.AspNetCore" Version="1.2.35" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Identity" Version="1.13.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />
@@ -12,16 +12,19 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="Bogus" Version="35.6.1" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Respawn" Version="6.2.1" />
-    <PackageVersion Include="Testcontainers" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="3.10.0" />
-    <PackageVersion Include="Polly" Version="8.4.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rc.2.24474.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0-rc.2.24473.5" />
+    <PackageVersion Include="Testcontainers" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.0.0" />
+    <PackageVersion Include="Polly" Version="8.5.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.7" />
   </ItemGroup>
 </Project>

--- a/tools/AppHost/AppHost.csproj
+++ b/tools/AppHost/AppHost.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0-rc.1.24511.1"/>
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="9.0.0-rc.1.24511.1"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-rc.2.24474.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/MigrationService/MigrationService.csproj
+++ b/tools/MigrationService/MigrationService.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-rc.1.24511.1" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
     <PackageReference Include="Bogus" Version="35.6.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/MigrationService/Worker.cs
+++ b/tools/MigrationService/Worker.cs
@@ -36,7 +36,7 @@ public class Worker(
         }
         catch (Exception ex)
         {
-            activity?.RecordException(ex);
+            activity?.AddException(ex);
             throw;
         }
 


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

#433 

> 2. What was changed?

This pull request includes several updates to package versions across multiple project files, transitioning from release candidates and preview versions to stable versions.

### Updates to package versions:

* [`global.json`](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL3-R5): Updated .NET SDK version to `9.0.100` and set `allowPrerelease` to `false`.

* [`src/Application/Application.csproj`](diffhunk://#diff-21ffebced6af4a53e697d1f5abf63e74d55d0d5828c1b530c6721285540a8e70L15-R17): Updated `Microsoft.EntityFrameworkCore`, `Microsoft.Extensions.DependencyInjection.Abstractions`, and `Microsoft.Extensions.Logging.Abstractions` to version `9.0.0`.

* [`src/Infrastructure/Infrastructure.csproj`](diffhunk://#diff-57ba390570d83de5303d5283c24e8358d4d51047587e1e490b7c637559f55c27L16-R22): Updated several packages to version `9.0.0`, including `Aspire.Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.Extensions.Http.Resilience`, and `Microsoft.Extensions.ServiceDiscovery`. Added `Microsoft.Extensions.Diagnostics.HealthChecks` and updated `OpenTelemetry` packages to version `1.10.0`.

* [`src/WebApi/WebApi.csproj`](diffhunk://#diff-14bca82630ad8e734f2571972ff5ea67cacb08c41f2482aa320f2a955fc9993fL17-R22): Updated `Microsoft.AspNetCore.OpenApi`, `Microsoft.EntityFrameworkCore.Design`, and `Scalar.AspNetCore` to stable versions. Removed explicit reference to `Azure.Identity`.

* [`tests/Directory.Packages.props`](diffhunk://#diff-f2d7cb17cbd9153d34ced5a7e9b05780ee28e5d7f00924b7e422c07c25e24bf3L7-R27): Updated multiple testing-related packages, including `FluentAssertions`, `coverlet.collector`, and `NSubstitute`, to their latest versions.

* [`tools/AppHost/AppHost.csproj`](diffhunk://#diff-cda82b6742843f6c1767221e433612d9fa582a55058b1f5ee6a5563151ba4656L12-R14): Updated `Aspire.Hosting.AppHost`, `Aspire.Hosting.SqlServer`, and `Microsoft.EntityFrameworkCore.SqlServer` to version `9.0.0`.

* [`tools/MigrationService/MigrationService.csproj`](diffhunk://#diff-4d0c133c7fbb6e9901bce3a4ee288a9c48c1e78edb738e9181801866895662e2L4-R6): Updated `Aspire.Microsoft.EntityFrameworkCore.SqlServer` and `Microsoft.Extensions.Hosting` to version `9.0.0`.

> 3. Did you do pair or mob programming?

No
