### PR TITLE
✨ 364 Add Vogen for Strongly Typed IDs

### DIFF
--- a/docs/adr/20241118-produce-useful-sql-server-exceptions.md
+++ b/docs/adr/20241118-produce-useful-sql-server-exceptions.md
@@ -25,3 +25,7 @@ Chosen option: "Option 1", because it does what we need and is far better than t
 
 - ✅ Strongly typed exceptions
 - ❌ Additional dependency added
+
+## Links
+
+- https://youtube.com/watch?v=QKwZlWvfh-o&si=yVnd5a7CVZaSV_Gr

--- a/docs/adr/20241118-replace-automapper-with-manual-mapping.md
+++ b/docs/adr/20241118-replace-automapper-with-manual-mapping.md
@@ -49,3 +49,7 @@ Chosen option: "Option 2 - Manual Mapper", because it reduces the runtime errors
 - ✅ Reduced runtime issues due to missing fields or mappings
 - ✅ No need to learn a new library
 - ❌ More code needed for mapping
+
+## Links
+
+- https://www.youtube.com/watch?v=RsnEZdc3MrE

--- a/docs/adr/20241118-use-vogen-to-simplify-strongly-typed-ids.md
+++ b/docs/adr/20241118-use-vogen-to-simplify-strongly-typed-ids.md
@@ -1,0 +1,46 @@
+# Use Vogen to simplify strongly typed IDs
+
+- Status: approved
+- Deciders: Daniel Mackay
+- Date: 2024-11-19
+- Tags: ddd, vogen, strongly-typed-ids
+
+Technical Story: https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/364
+
+## Context and Problem Statement
+
+Strongly typed IDs are a great way to combat primitive obsession. However, they can be a bit of a pain to set up especially with EF Core. We want to make it easier to use strongly typed IDs or any simple value objects in our projects.
+
+## Decision Drivers <!-- optional -->
+
+- Simplify usage of strongly typed IDs
+
+## Considered Options
+
+1. Manual Approach
+2. Vogen
+
+## Decision Outcome
+
+Chosen option: "Option 2 - Vogen", because configuration, validation, and usage of strongly typed IDs is much simpler (espeicially from the EF Core point of view).
+
+## Pros and Cons of the Options <!-- optional -->
+
+### Option 1 - Manual Approach
+
+- ✅ Avoid additional dependencies
+- ❌ Extra EF Core boilerplate needed
+- ❌ Not easy to add value object validation with current record-based approach
+
+### Option 2 - Vogen
+
+- ✅ Simple to create and use strongly typed IDs
+- ✅ Easy to add value object validation
+- ✅ Easy to add EF Core configuration
+- ✅ Can be used for any simple value object
+- ❌ Extra dependency added
+
+## Links
+
+- https://stevedunn.github.io/Vogen/overview.html
+- https://github.com/SteveDunn/Vogen

--- a/src/Application/UseCases/Heroes/Commands/UpdateHero/UpdateHeroCommand.cs
+++ b/src/Application/UseCases/Heroes/Commands/UpdateHero/UpdateHeroCommand.cs
@@ -20,7 +20,7 @@ internal sealed class UpdateHeroCommandHandler(IApplicationDbContext dbContext)
 {
     public async Task<ErrorOr<Guid>> Handle(UpdateHeroCommand request, CancellationToken cancellationToken)
     {
-        var heroId = new HeroId(request.HeroId);
+        var heroId = HeroId.From(request.HeroId);
         var hero = await dbContext.Heroes
             .Include(h => h.Powers)
             .FirstOrDefaultAsync(h => h.Id == heroId, cancellationToken);

--- a/src/Application/UseCases/Teams/Commands/AddHeroToTeam/AddHeroToTeamCommand.cs
+++ b/src/Application/UseCases/Teams/Commands/AddHeroToTeam/AddHeroToTeamCommand.cs
@@ -11,8 +11,8 @@ internal sealed class AddHeroToTeamCommandHandler(IApplicationDbContext dbContex
 {
     public async Task<ErrorOr<Success>> Handle(AddHeroToTeamCommand request, CancellationToken cancellationToken)
     {
-        var teamId = new TeamId(request.TeamId);
-        var heroId = new HeroId(request.HeroId);
+        var teamId = TeamId.From(request.TeamId);
+        var heroId = HeroId.From(request.HeroId);
 
         var team = dbContext.Teams
             .WithSpecification(new TeamByIdSpec(teamId))

--- a/src/Application/UseCases/Teams/Commands/CompleteMission/CompleteMissionCommand.cs
+++ b/src/Application/UseCases/Teams/Commands/CompleteMission/CompleteMissionCommand.cs
@@ -10,7 +10,7 @@ internal sealed class CompleteMissionCommandHandler(IApplicationDbContext dbCont
 {
     public async Task<ErrorOr<Success>> Handle(CompleteMissionCommand request, CancellationToken cancellationToken)
     {
-        var teamId = new TeamId(request.TeamId);
+        var teamId = TeamId.From(request.TeamId);
         var team = dbContext.Teams
             .WithSpecification(new TeamByIdSpec(teamId))
             .FirstOrDefault();

--- a/src/Application/UseCases/Teams/Commands/ExecuteMission/ExecuteMissionCommand.cs
+++ b/src/Application/UseCases/Teams/Commands/ExecuteMission/ExecuteMissionCommand.cs
@@ -14,7 +14,7 @@ internal sealed class ExecuteMissionCommandHandler(IApplicationDbContext dbConte
 {
     public async Task<ErrorOr<Success>> Handle(ExecuteMissionCommand request, CancellationToken cancellationToken)
     {
-        var teamId = new TeamId(request.TeamId);
+        var teamId = TeamId.From(request.TeamId);
         var team = dbContext.Teams
             .WithSpecification(new TeamByIdSpec(teamId))
             .FirstOrDefault();

--- a/src/Application/UseCases/Teams/Events/PowerLevelUpdatedEventHandler.cs
+++ b/src/Application/UseCases/Teams/Events/PowerLevelUpdatedEventHandler.cs
@@ -26,7 +26,7 @@ internal sealed class PowerLevelUpdatedEventHandler(
         }
 
         var team = dbContext.Teams
-            .WithSpecification(new TeamByIdSpec(hero.TeamId))
+            .WithSpecification(new TeamByIdSpec(hero.TeamId.Value))
             .FirstOrDefault();
 
         if (team is null)

--- a/src/Application/UseCases/Teams/Queries/GetTeam/GetTeamQuery.cs
+++ b/src/Application/UseCases/Teams/Queries/GetTeam/GetTeamQuery.cs
@@ -16,7 +16,7 @@ internal sealed class GetAllTeamsQueryHandler(IApplicationDbContext dbContext)
         GetTeamQuery request,
         CancellationToken cancellationToken)
     {
-        var teamId = new TeamId(request.TeamId);
+        var teamId = TeamId.From(request.TeamId);
 
         var team = await dbContext.Teams
             .Where(t => t.Id == teamId)

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -7,5 +7,6 @@
     <PackageReference Include="Ardalis.Specification" Version="8.0.0" />
     <PackageReference Include="ErrorOr" Version="2.0.1" />
     <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
+    <PackageReference Include="Vogen" Version="5.0.5" />
   </ItemGroup>
 </Project>

--- a/src/Domain/Heroes/Hero.cs
+++ b/src/Domain/Heroes/Hero.cs
@@ -1,13 +1,11 @@
-﻿using SSW.CleanArchitecture.Domain.Common.Base;
-using SSW.CleanArchitecture.Domain.Teams;
+﻿using SSW.CleanArchitecture.Domain.Teams;
+using Vogen;
 
 namespace SSW.CleanArchitecture.Domain.Heroes;
 
 // For strongly typed IDs, check out the rule: https://www.ssw.com.au/rules/do-you-use-strongly-typed-ids/
-public readonly record struct HeroId(Guid Value)
-{
-    public HeroId() : this(Guid.CreateVersion7()) { }
-}
+[ValueObject<Guid>]
+public readonly partial struct HeroId;
 
 public class Hero : AggregateRoot<HeroId>
 {
@@ -24,7 +22,7 @@ public class Hero : AggregateRoot<HeroId>
     public static Hero Create(string name, string alias)
     {
         Guid.CreateVersion7();
-        var hero = new Hero { Id = new HeroId(Guid.CreateVersion7()) };
+        var hero = new Hero { Id = HeroId.From(Guid.CreateVersion7()) };
         hero.UpdateName(name);
         hero.UpdateAlias(alias);
 

--- a/src/Domain/Heroes/Power.cs
+++ b/src/Domain/Heroes/Power.cs
@@ -1,6 +1,4 @@
-﻿using SSW.CleanArchitecture.Domain.Common.Interfaces;
-
-namespace SSW.CleanArchitecture.Domain.Heroes;
+﻿namespace SSW.CleanArchitecture.Domain.Heroes;
 
 public record Power : IValueObject
 {

--- a/src/Domain/Teams/Mission.cs
+++ b/src/Domain/Teams/Mission.cs
@@ -1,10 +1,10 @@
-﻿using ErrorOr;
-using SSW.CleanArchitecture.Domain.Common.Base;
+﻿using Vogen;
 
 namespace SSW.CleanArchitecture.Domain.Teams;
 
 // For strongly typed IDs, check out the rule: https://www.ssw.com.au/rules/do-you-use-strongly-typed-ids/
-public readonly record struct MissionId(Guid Value);
+[ValueObject<Guid>]
+public readonly partial struct MissionId;
 
 public class Mission : Entity<MissionId>
 {
@@ -20,7 +20,7 @@ public class Mission : Entity<MissionId>
         ThrowIfNullOrWhiteSpace(description);
         return new Mission
         {
-            Id = new MissionId(Guid.CreateVersion7()),
+            Id = MissionId.From(Guid.CreateVersion7()),
             Description = description,
             Status = MissionStatus.InProgress
         };

--- a/src/Domain/Teams/Team.cs
+++ b/src/Domain/Teams/Team.cs
@@ -1,12 +1,11 @@
-﻿using ErrorOr;
-using SSW.CleanArchitecture.Domain.Common.Base;
-using SSW.CleanArchitecture.Domain.Common.Interfaces;
-using SSW.CleanArchitecture.Domain.Heroes;
+﻿using SSW.CleanArchitecture.Domain.Heroes;
+using Vogen;
 
 namespace SSW.CleanArchitecture.Domain.Teams;
 
 // For strongly typed IDs, check out the rule: https://www.ssw.com.au/rules/do-you-use-strongly-typed-ids/
-public sealed record TeamId(Guid Value);
+[ValueObject<Guid>]
+public readonly partial struct TeamId;
 
 public class Team : AggregateRoot<TeamId>
 {
@@ -27,7 +26,7 @@ public class Team : AggregateRoot<TeamId>
     {
         ThrowIfNullOrWhiteSpace(name);
 
-        var team = new Team { Id = new TeamId(Guid.CreateVersion7()), Name = name, Status = TeamStatus.Available };
+        var team = new Team { Id = TeamId.From(Guid.CreateVersion7()), Name = name, Status = TeamStatus.Available };
 
         return team;
     }

--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -3,12 +3,12 @@ using SSW.CleanArchitecture.Application.Common.Interfaces;
 using SSW.CleanArchitecture.Domain.Common.Interfaces;
 using SSW.CleanArchitecture.Domain.Heroes;
 using SSW.CleanArchitecture.Domain.Teams;
+using SSW.CleanArchitecture.Infrastructure.Persistence.Configuration;
 using System.Reflection;
 
 namespace SSW.CleanArchitecture.Infrastructure.Persistence;
 
-public class ApplicationDbContext(
-    DbContextOptions options)
+public class ApplicationDbContext(DbContextOptions options)
     : DbContext(options), IApplicationDbContext
 {
     public DbSet<Hero> Heroes => AggregateRootSet<Hero>();
@@ -26,8 +26,8 @@ public class ApplicationDbContext(
     {
         base.ConfigureConventions(configurationBuilder);
 
-        configurationBuilder.Properties<string>()
-            .HaveMaxLength(256);
+        configurationBuilder.Properties<string>().HaveMaxLength(256);
+        configurationBuilder.RegisterAllInVogenEfCoreConverters();
     }
 
     private DbSet<T> AggregateRootSet<T>() where T : class, IAggregateRoot => Set<T>();

--- a/src/Infrastructure/Persistence/Configuration/HeroConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configuration/HeroConfiguration.cs
@@ -10,11 +10,6 @@ public class HeroConfiguration : IEntityTypeConfiguration<Hero>
     {
         builder.HasKey(t => t.Id);
 
-        // builder.Property(t => t.Id)
-        //     .HasConversion(x => x.Value,
-        //         x => new HeroId(x))
-        //     .ValueGeneratedNever();
-
         builder.Property(t => t.Name)
             .IsRequired();
 

--- a/src/Infrastructure/Persistence/Configuration/HeroConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configuration/HeroConfiguration.cs
@@ -6,15 +6,14 @@ namespace SSW.CleanArchitecture.Infrastructure.Persistence.Configuration;
 
 public class HeroConfiguration : IEntityTypeConfiguration<Hero>
 {
-    // TODO: Figure out a good marker (e.g. for recurring fields ID) to enforce that all entities have configuration defined via arch tests
     public void Configure(EntityTypeBuilder<Hero> builder)
     {
         builder.HasKey(t => t.Id);
 
-        builder.Property(t => t.Id)
-            .HasConversion(x => x.Value,
-                x => new HeroId(x))
-            .ValueGeneratedNever();
+        // builder.Property(t => t.Id)
+        //     .HasConversion(x => x.Value,
+        //         x => new HeroId(x))
+        //     .ValueGeneratedNever();
 
         builder.Property(t => t.Name)
             .IsRequired();

--- a/src/Infrastructure/Persistence/Configuration/MissionConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configuration/MissionConfiguration.cs
@@ -6,15 +6,14 @@ namespace SSW.CleanArchitecture.Infrastructure.Persistence.Configuration;
 
 public class MissionConfiguration : IEntityTypeConfiguration<Mission>
 {
-    // TODO: Figure out a good marker (e.g. for recurring fields ID) to enforce that all entities have configuration defined via arch tests
     public void Configure(EntityTypeBuilder<Mission> builder)
     {
         builder.HasKey(t => t.Id);
 
-        builder.Property(t => t.Id)
-            .HasConversion(x => x.Value,
-                x => new MissionId(x))
-            .ValueGeneratedNever();
+        // builder.Property(t => t.Id)
+        //     .HasConversion(x => x.Value,
+        //         x => new MissionId(x))
+        //     .ValueGeneratedNever();
 
         builder.Property(t => t.Description)
             .IsRequired();

--- a/src/Infrastructure/Persistence/Configuration/MissionConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configuration/MissionConfiguration.cs
@@ -10,11 +10,6 @@ public class MissionConfiguration : IEntityTypeConfiguration<Mission>
     {
         builder.HasKey(t => t.Id);
 
-        // builder.Property(t => t.Id)
-        //     .HasConversion(x => x.Value,
-        //         x => new MissionId(x))
-        //     .ValueGeneratedNever();
-
         builder.Property(t => t.Description)
             .IsRequired();
     }

--- a/src/Infrastructure/Persistence/Configuration/TeamConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configuration/TeamConfiguration.cs
@@ -10,11 +10,6 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
     {
         builder.HasKey(t => t.Id);
 
-        // builder.Property(t => t.Id)
-        //     .HasConversion(x => x.Value,
-        //         x => new TeamId(x))
-        //     .ValueGeneratedNever();
-
         builder.Property(t => t.Name)
             .IsRequired();
 

--- a/src/Infrastructure/Persistence/Configuration/TeamConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configuration/TeamConfiguration.cs
@@ -6,15 +6,14 @@ namespace SSW.CleanArchitecture.Infrastructure.Persistence.Configuration;
 
 public class TeamConfiguration : IEntityTypeConfiguration<Team>
 {
-    // TODO: Figure out a good marker (e.g. for recurring fields ID) to enforce that all entities have configuration defined via arch tests
     public void Configure(EntityTypeBuilder<Team> builder)
     {
         builder.HasKey(t => t.Id);
 
-        builder.Property(t => t.Id)
-            .HasConversion(x => x.Value,
-                x => new TeamId(x))
-            .ValueGeneratedNever();
+        // builder.Property(t => t.Id)
+        //     .HasConversion(x => x.Value,
+        //         x => new TeamId(x))
+        //     .ValueGeneratedNever();
 
         builder.Property(t => t.Name)
             .IsRequired();

--- a/src/Infrastructure/Persistence/Configuration/VogenEfCoreConverters.cs
+++ b/src/Infrastructure/Persistence/Configuration/VogenEfCoreConverters.cs
@@ -1,0 +1,10 @@
+using SSW.CleanArchitecture.Domain.Heroes;
+using SSW.CleanArchitecture.Domain.Teams;
+using Vogen;
+
+namespace SSW.CleanArchitecture.Infrastructure.Persistence.Configuration;
+
+[EfCoreConverter<TeamId>]
+[EfCoreConverter<HeroId>]
+[EfCoreConverter<MissionId>]
+internal partial class VogenEfCoreConverters;

--- a/src/Infrastructure/Persistence/Configuration/VogenEfCoreConverters.cs
+++ b/src/Infrastructure/Persistence/Configuration/VogenEfCoreConverters.cs
@@ -7,4 +7,4 @@ namespace SSW.CleanArchitecture.Infrastructure.Persistence.Configuration;
 [EfCoreConverter<TeamId>]
 [EfCoreConverter<HeroId>]
 [EfCoreConverter<MissionId>]
-internal partial class VogenEfCoreConverters;
+internal sealed partial class VogenEfCoreConverters;

--- a/tests/Architecture.Tests/DomainTests.cs
+++ b/tests/Architecture.Tests/DomainTests.cs
@@ -2,10 +2,11 @@
 using SSW.CleanArchitecture.Domain.Common.Base;
 using SSW.CleanArchitecture.Domain.Common.Interfaces;
 using System.Reflection;
+using Xunit.Abstractions;
 
 namespace SSW.CleanArchitecture.Architecture.UnitTests;
 
-public class DomainModel : TestBase
+public class DomainModel(ITestOutputHelper output) : TestBase
 {
     private static readonly Type AggregateRoot = typeof(AggregateRoot<>);
     private static readonly Type Entity = typeof(Entity<>);
@@ -19,10 +20,14 @@ public class DomainModel : TestBase
         var domainModels = Types.InAssembly(DomainAssembly)
             .That()
             .DoNotResideInNamespaceContaining("Common")
-            .And().DoNotHaveNameEndingWith("Id")
+            .And().DoNotHaveNameMatching(".*Id.*")
+            .And().DoNotHaveNameMatching(".*Vogen.*")
+            .And().DoNotHaveName("ThrowHelper")
             .And().DoNotHaveNameEndingWith("Spec")
             .And().DoNotHaveNameEndingWith("Errors")
             .And().MeetCustomRule(new IsNotEnumRule());
+
+        domainModels.GetTypes().Dump(output);
 
         // Act
         var result = domainModels

--- a/tests/Domain.UnitTests/Heroes/HeroTests.cs
+++ b/tests/Domain.UnitTests/Heroes/HeroTests.cs
@@ -12,8 +12,8 @@ public class HeroTests
         // Arrange
         Guid guid1 = Guid.Parse(stringGuid1);
         Guid guid2 = Guid.Parse(stringGuid2);
-        HeroId id1 = new(guid1);
-        HeroId id2 = new(guid2);
+        HeroId id1 = HeroId.From(guid1);
+        HeroId id2 = HeroId.From(guid2);
 
         // Act
         var areEqual = id1 == id2;
@@ -100,7 +100,7 @@ public class HeroTests
     {
         // Act
         var hero = Hero.Create("name", "alias");
-        hero.Id = new HeroId();
+        hero.Id = HeroId.From(Guid.NewGuid());
         hero.UpdatePowers([new Power("Super-strength", 10)]);
 
         // Assert

--- a/tests/Domain.UnitTests/Teams/MissionTests.cs
+++ b/tests/Domain.UnitTests/Teams/MissionTests.cs
@@ -12,8 +12,8 @@ public class MissionTests
         // Arrange
         Guid guid1 = Guid.Parse(stringGuid1);
         Guid guid2 = Guid.Parse(stringGuid2);
-        MissionId id1 = new(guid1);
-        MissionId id2 = new(guid2);
+        MissionId id1 = MissionId.From(guid1);
+        MissionId id2 = MissionId.From(guid2);
 
         // Act
         var areEqual = id1 == id2;

--- a/tests/Domain.UnitTests/Teams/TeamTests.cs
+++ b/tests/Domain.UnitTests/Teams/TeamTests.cs
@@ -13,8 +13,8 @@ public class TeamTests
         // Arrange
         Guid guid1 = Guid.Parse(stringGuid1);
         Guid guid2 = Guid.Parse(stringGuid2);
-        TeamId id1 = new(guid1);
-        TeamId id2 = new(guid2);
+        TeamId id1 = TeamId.From(guid1);
+        TeamId id2 = TeamId.From(guid2);
 
         // Act
         var areEqual = id1 == id2;

--- a/tests/WebApi.IntegrationTests/Endpoints/Heroes/Commands/UpdateHeroCommandTests.cs
+++ b/tests/WebApi.IntegrationTests/Endpoints/Heroes/Commands/UpdateHeroCommandTests.cs
@@ -54,7 +54,7 @@ public class UpdateHeroCommandTests(TestingDatabaseFixture fixture, ITestOutputH
     public async Task Command_WhenHeroDoesNotExist_ShouldReturnNotFound()
     {
         // Arrange
-        var heroId = new HeroId();
+        var heroId = HeroId.From(Guid.NewGuid());
         var cmd = new UpdateHeroCommand(
             "foo",
             "bar",


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/364

> 2. What was changed?

This pull request includes several changes aimed at refactoring the codebase to use strongly typed IDs and improving the configuration of the Entity Framework Core (EF Core) models. The most important changes include the introduction of the `Vogen` library for value objects, updates to the `HeroId`, `TeamId`, and `MissionId` types, and adjustments to the entity configurations.

Refactoring to use strongly typed IDs:

* [`src/Domain/Heroes/Hero.cs`](diffhunk://#diff-094ca6729cc59148d9d65db00c747f8731a9f56aed4f12867002e9a94daa978eL1-R8): Replaced the `HeroId` struct with a `Vogen` value object and updated the `Create` method to use `HeroId.From`. [[1]](diffhunk://#diff-094ca6729cc59148d9d65db00c747f8731a9f56aed4f12867002e9a94daa978eL1-R8) [[2]](diffhunk://#diff-094ca6729cc59148d9d65db00c747f8731a9f56aed4f12867002e9a94daa978eL27-R25)
* [`src/Domain/Teams/Mission.cs`](diffhunk://#diff-e86b86e8d9c61a37430fe20b10f36babbf758234004a90a86dc6327491fd1a49L1-R7): Replaced the `MissionId` struct with a `Vogen` value object and updated the `Create` method to use `MissionId.From`. [[1]](diffhunk://#diff-e86b86e8d9c61a37430fe20b10f36babbf758234004a90a86dc6327491fd1a49L1-R7) [[2]](diffhunk://#diff-e86b86e8d9c61a37430fe20b10f36babbf758234004a90a86dc6327491fd1a49L23-R23)
* [`src/Domain/Teams/Team.cs`](diffhunk://#diff-2d226224d80d8dd6220ddfe88798da1a3734a838c0a6fb158bdbf362cb0f6159L1-R8): Replaced the `TeamId` struct with a `Vogen` value object and updated the `Create` method to use `TeamId.From`. [[1]](diffhunk://#diff-2d226224d80d8dd6220ddfe88798da1a3734a838c0a6fb158bdbf362cb0f6159L1-R8) [[2]](diffhunk://#diff-2d226224d80d8dd6220ddfe88798da1a3734a838c0a6fb158bdbf362cb0f6159L30-R29)

Entity Framework Core configuration updates:

* [`src/Infrastructure/Persistence/ApplicationDbContext.cs`](diffhunk://#diff-2225a3e497a33a8e5fc2e3205d34155f700ad43352f7349d7979c8ce735afb7dL29-R30): Added the `RegisterAllInVogenEfCoreConverters` method call in `ConfigureConventions` to register the Vogen converters.
* `src/Infrastructure/Persistence/Configuration/HeroConfiguration.cs`, `MissionConfiguration.cs`, `TeamConfiguration.cs`: Commented out the manual conversions for `HeroId`, `MissionId`, and `TeamId` as they are now handled by Vogen's EF Core converters. [[1]](diffhunk://#diff-f52f805d178b2208043d6fdf854ba7ec869066db1a1c58ac2c538a0a1fcdf344L9-R16) [[2]](diffhunk://#diff-8d2fb9e153d844a7660f2db3973b3f2274e1aa8e6cf23a9db0510f0ea8a52579L9-R16) [[3]](diffhunk://#diff-56883c9c008170f7bc9e9d94832adc4f0f2115587941a1324215393ce451aeb3L9-R16)

Additional changes:

* [`src/Domain/Domain.csproj`](diffhunk://#diff-6b386feb9fd7e1e3bb38c2839ad39436c807e63707bd4a6e24cef63f6fb6f772R10): Added the `Vogen` package reference.
* `tests/Domain.UnitTests/Heroes/HeroTests.cs`, `MissionTests.cs`, `TeamTests.cs`: Updated tests to use the `HeroId.From`, `MissionId.From`, and `TeamId.From` methods. [[1]](diffhunk://#diff-4c7f292239416ca77b6f365c40f805e51415b65583708a871abb4619c3d31009L15-R16) [[2]](diffhunk://#diff-4c7f292239416ca77b6f365c40f805e51415b65583708a871abb4619c3d31009L103-R103) [[3]](diffhunk://#diff-2d43a835f14cc34a08ac74a25376a803330f318175f3120e870ad88f2862943aL15-R16) [[4]](diffhunk://#diff-5d9ae51f3df25aad6f5d5fba670625099a620e47c12bfa3695d547e174e9cb42L16-R17)

> 3. Did you do pair or mob programming?

No
