### PR TITLE
✨ 431 enhanced problem details

### DIFF
--- a/docs/adr/20241118-produce-useful-sql-server-exceptions.md
+++ b/docs/adr/20241118-produce-useful-sql-server-exceptions.md
@@ -1,6 +1,6 @@
 # Produce useful SQL Server exceptions
 
-- Status: approved
+- Status: accepted
 - Deciders: Daniel Mackay
 - Date: 2024-11-18
 - Tags: ef-core

--- a/docs/adr/20241118-replace-automapper-with-manual-mapping.md
+++ b/docs/adr/20241118-replace-automapper-with-manual-mapping.md
@@ -1,6 +1,6 @@
 # Replace AutoMapper with manual mapping
 
-- Status: Approved
+- Status: accepted
 - Deciders: Daniel Mackay, Matt Goldman
 - Date: 2024-11-18
 - Tags: mappers

--- a/docs/adr/20241118-use-vogen-to-simplify-strongly-typed-ids.md
+++ b/docs/adr/20241118-use-vogen-to-simplify-strongly-typed-ids.md
@@ -1,6 +1,6 @@
 # Use Vogen to simplify strongly typed IDs
 
-- Status: approved
+- Status: accepted
 - Deciders: Daniel Mackay
 - Date: 2024-11-19
 - Tags: ddd, vogen, strongly-typed-ids

--- a/src/WebApi/Extensions/CustomProblemDetailsExt.cs
+++ b/src/WebApi/Extensions/CustomProblemDetailsExt.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Http.Features;
+
+namespace SSW.CleanArchitecture.WebApi.Extensions;
+
+public static class CustomProblemDetailsExt
+{
+    public static void AddCustomProblemDetails(this IServiceCollection services)
+    {
+        services.AddProblemDetails(options =>
+        {
+            options.CustomizeProblemDetails = context =>
+            {
+                context.ProblemDetails.Instance = $"{context.HttpContext.Request.Method} {context.HttpContext.Request.Path}";
+
+                context.ProblemDetails.Extensions.TryAdd("requestId", context.HttpContext.TraceIdentifier);
+
+                var activity = context.HttpContext.Features.Get<IHttpActivityFeature>()?.Activity;
+                context.ProblemDetails.Extensions.TryAdd("traceId", activity?.Id);
+            };
+        });
+    }
+}

--- a/src/WebApi/Extensions/CustomScalarExt.cs
+++ b/src/WebApi/Extensions/CustomScalarExt.cs
@@ -1,0 +1,11 @@
+using Scalar.AspNetCore;
+
+namespace SSW.CleanArchitecture.WebApi.Extensions;
+
+public static class CustomScalarExt
+{
+    public static void MapCustomScalarApiReference(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapScalarApiReference(options => options.WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient));
+    }
+}

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,4 +1,3 @@
-using Scalar.AspNetCore;
 using SSW.CleanArchitecture.Application;
 using SSW.CleanArchitecture.Infrastructure;
 using SSW.CleanArchitecture.WebApi;
@@ -9,7 +8,7 @@ using SSW.CleanArchitecture.WebApi.HealthChecks;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
-builder.Services.AddProblemDetails();
+builder.Services.AddCustomProblemDetails();
 
 builder.Services.AddWebApi(builder.Configuration);
 builder.Services.AddApplication();
@@ -29,7 +28,7 @@ else
 }
 
 app.MapOpenApi();
-app.MapScalarApiReference(options => options.WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient));
+app.MapCustomScalarApiReference();
 app.UseHealthChecks();
 app.UseHttpsRedirection();
 app.UseStaticFiles();


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/431

> 2. What was changed?

This pull request includes several changes to improve the handling of exceptions and API references in the `WebApi` project, as well as updates to ADR documentation statuses. The most important changes are grouped by theme below:

### Documentation Updates:
* Updated the status of ADR documents from "approved" to "accepted" to reflect the current decision status. (`docs/adr/20241118-produce-useful-sql-server-exceptions.md`, `docs/adr/20241118-replace-automapper-with-manual-mapping.md`, `docs/adr/20241118-use-vogen-to-simplify-strongly-typed-ids.md`) [[1]](diffhunk://#diff-60ebb93559b2ee4bc3c13eb0b97698d2fe4869c82456e52936ebad070a89f02fL3-R3) [[2]](diffhunk://#diff-efc375f330c424dda2a6fde290bc7f4f767888082f378433b504b0f541ad4164L3-R3) [[3]](diffhunk://#diff-c9b23ddd2cc112c520f592edb866fcb1b7005210d9d53a19173dae5c0ee41d7fL3-R3)

### Exception Handling Improvements:
* Added a new extension method `AddCustomProblemDetails` in `CustomProblemDetailsExt.cs` to customize problem details in HTTP responses. (`src/WebApi/Extensions/CustomProblemDetailsExt.cs`)
* Updated `Program.cs` to use the new `AddCustomProblemDetails` method instead of the default `AddProblemDetails` method. (`src/WebApi/Program.cs`)

### API Reference Mapping:
* Added a new extension method `MapCustomScalarApiReference` in `CustomScalarExt.cs` to map Scalar API references with a default HTTP client. (`src/WebApi/Extensions/CustomScalarExt.cs`)
* Updated `Program.cs` to use the new `MapCustomScalarApiReference` method instead of directly mapping Scalar API references. (`src/WebApi/Program.cs`)

> 3. Did you do pair or mob programming?

No
