### PR TITLE
💬 Added links to specification rule

### DIFF
--- a/src/Domain/Common/Base/AggregateRoot.cs
+++ b/src/Domain/Common/Base/AggregateRoot.cs
@@ -1,7 +1,4 @@
-﻿using SSW.CleanArchitecture.Domain.Common.Interfaces;
-using System.ComponentModel.DataAnnotations.Schema;
-
-namespace SSW.CleanArchitecture.Domain.Common.Base;
+﻿namespace SSW.CleanArchitecture.Domain.Common.Base;
 
 /// <summary>
 /// Cluster of objects treated as a single unit.

--- a/src/Domain/Common/Base/Auditable.cs
+++ b/src/Domain/Common/Base/Auditable.cs
@@ -1,6 +1,4 @@
-﻿using SSW.CleanArchitecture.Domain.Common.Interfaces;
-
-namespace SSW.CleanArchitecture.Domain.Common.Base;
+﻿namespace SSW.CleanArchitecture.Domain.Common.Base;
 
 /// <summary>
 /// Tracks creation and modification of objects.

--- a/src/Domain/Common/EventualConsistency/EventualConsistencyError.cs
+++ b/src/Domain/Common/EventualConsistency/EventualConsistencyError.cs
@@ -1,5 +1,3 @@
-using ErrorOr;
-
 namespace SSW.CleanArchitecture.Domain.Common.EventualConsistency;
 
 public static class EventualConsistencyError

--- a/src/Domain/Common/EventualConsistency/EventualConsistencyException.cs
+++ b/src/Domain/Common/EventualConsistency/EventualConsistencyException.cs
@@ -1,5 +1,3 @@
-using ErrorOr;
-
 namespace SSW.CleanArchitecture.Domain.Common.EventualConsistency;
 
 public class EventualConsistencyException : Exception

--- a/src/Domain/GlobalUsings.cs
+++ b/src/Domain/GlobalUsings.cs
@@ -1,5 +1,6 @@
 // Global using directives
 
+global using Ardalis.Specification;
 global using static System.ArgumentException;
 global using static System.ArgumentNullException;
 global using static System.ArgumentOutOfRangeException;
@@ -7,3 +8,4 @@ global using SSW.CleanArchitecture.Domain.Common.Base;
 global using SSW.CleanArchitecture.Domain.Common.EventualConsistency;
 global using SSW.CleanArchitecture.Domain.Common.Interfaces;
 global using ErrorOr;
+global using Vogen;

--- a/src/Domain/Heroes/Hero.cs
+++ b/src/Domain/Heroes/Hero.cs
@@ -1,5 +1,4 @@
 ﻿using SSW.CleanArchitecture.Domain.Teams;
-using Vogen;
 
 namespace SSW.CleanArchitecture.Domain.Heroes;
 

--- a/src/Domain/Heroes/HeroErrors.cs
+++ b/src/Domain/Heroes/HeroErrors.cs
@@ -1,5 +1,3 @@
-using ErrorOr;
-
 namespace SSW.CleanArchitecture.Domain.Heroes;
 
 public static class HeroErrors

--- a/src/Domain/Heroes/PowerLevelUpdatedEvent.cs
+++ b/src/Domain/Heroes/PowerLevelUpdatedEvent.cs
@@ -1,8 +1,4 @@
-﻿using ErrorOr;
-using SSW.CleanArchitecture.Domain.Common.EventualConsistency;
-using SSW.CleanArchitecture.Domain.Common.Interfaces;
-
-namespace SSW.CleanArchitecture.Domain.Heroes;
+﻿namespace SSW.CleanArchitecture.Domain.Heroes;
 
 public record PowerLevelUpdatedEvent(Hero Hero) : IDomainEvent
 {

--- a/src/Domain/Heroes/TeamByIdSpec.cs
+++ b/src/Domain/Heroes/TeamByIdSpec.cs
@@ -1,7 +1,6 @@
-﻿using Ardalis.Specification;
+﻿namespace SSW.CleanArchitecture.Domain.Heroes;
 
-namespace SSW.CleanArchitecture.Domain.Heroes;
-
+// For more on the Specification Pattern see: https://www.ssw.com.au/rules/use-specification-pattern/
 public sealed class HeroByIdSpec : SingleResultSpecification<Hero>
 {
     public HeroByIdSpec(HeroId heroId)

--- a/src/Domain/Teams/Mission.cs
+++ b/src/Domain/Teams/Mission.cs
@@ -1,6 +1,4 @@
-﻿using Vogen;
-
-namespace SSW.CleanArchitecture.Domain.Teams;
+﻿namespace SSW.CleanArchitecture.Domain.Teams;
 
 // For strongly typed IDs, check out the rule: https://www.ssw.com.au/rules/do-you-use-strongly-typed-ids/
 [ValueObject<Guid>]

--- a/src/Domain/Teams/MissionErrors.cs
+++ b/src/Domain/Teams/MissionErrors.cs
@@ -1,5 +1,3 @@
-using ErrorOr;
-
 namespace SSW.CleanArchitecture.Domain.Teams;
 
 public static class MissionErrors

--- a/src/Domain/Teams/Team.cs
+++ b/src/Domain/Teams/Team.cs
@@ -1,5 +1,4 @@
 ﻿using SSW.CleanArchitecture.Domain.Heroes;
-using Vogen;
 
 namespace SSW.CleanArchitecture.Domain.Teams;
 

--- a/src/Domain/Teams/TeamByIdSpec.cs
+++ b/src/Domain/Teams/TeamByIdSpec.cs
@@ -1,7 +1,6 @@
-﻿using Ardalis.Specification;
+﻿namespace SSW.CleanArchitecture.Domain.Teams;
 
-namespace SSW.CleanArchitecture.Domain.Teams;
-
+// For more on the Specification Pattern see: https://www.ssw.com.au/rules/use-specification-pattern/
 public sealed class TeamByIdSpec : SingleResultSpecification<Team>
 {
     public TeamByIdSpec(TeamId teamId)

--- a/src/Domain/Teams/TeamErrors.cs
+++ b/src/Domain/Teams/TeamErrors.cs
@@ -1,5 +1,3 @@
-using ErrorOr;
-
 namespace SSW.CleanArchitecture.Domain.Teams;
 
 public static class TeamErrors

--- a/src/Infrastructure/Middleware/EventualConsistencyMiddleware.cs
+++ b/src/Infrastructure/Middleware/EventualConsistencyMiddleware.cs
@@ -1,11 +1,9 @@
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 using SSW.CleanArchitecture.Domain.Common.EventualConsistency;
 using SSW.CleanArchitecture.Domain.Common.Interfaces;
 using SSW.CleanArchitecture.Infrastructure.Persistence;
-using System.Transactions;
 
 namespace SSW.CleanArchitecture.Infrastructure.Middleware;
 

--- a/tools/MigrationService/Worker.cs
+++ b/tools/MigrationService/Worker.cs
@@ -1,5 +1,4 @@
 using MigrationService.Initializers;
-using OpenTelemetry.Trace;
 using System.Diagnostics;
 
 namespace MigrationService;


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

https://github.com/SSWConsulting/SSW.CleanArchitecture/issues/338

> 2. What was changed?

This pull request involves several changes aimed at cleaning up unused `using` directives and adding global using directives to the `GlobalUsings.cs` file. Below is a summary of the most important changes:

### Removal of Unused `using` Directives:

* [`src/Domain/Common/Base/AggregateRoot.cs`](diffhunk://#diff-6673bbfbcc38dcf827ffdbccca815084ddf5f14b41095c98e332260288e16ca2L1-R1): Removed unused `using` directives (`SSW.CleanArchitecture.Domain.Common.Interfaces` and `System.ComponentModel.DataAnnotations.Schema`).
* [`src/Domain/Common/Base/Auditable.cs`](diffhunk://#diff-7f61c1a655bdfa4cd99a37fba4dcc331ab6a49393378babd32b03927376e375cL1-R1): Removed unused `using` directive (`SSW.CleanArchitecture.Domain.Common.Interfaces`).
* [`src/Domain/Common/EventualConsistency/EventualConsistencyError.cs`](diffhunk://#diff-a94d4ff758f192b1b517144eaf21467a2df3326b15e05f2a4a42ea18748e9793L1-L2): Removed unused `using` directive (`ErrorOr`).
* [`src/Domain/Common/EventualConsistency/EventualConsistencyException.cs`](diffhunk://#diff-ebcfd10c4d3749b08cc6fbc51969c843bd85ece8eb6611b50a34acd5a8d090a8L1-L2): Removed unused `using` directive (`ErrorOr`).
* [`src/Domain/Heroes/Hero.cs`](diffhunk://#diff-094ca6729cc59148d9d65db00c747f8731a9f56aed4f12867002e9a94daa978eL2): Removed unused `using` directive (`Vogen`).
* [`src/Domain/Heroes/HeroErrors.cs`](diffhunk://#diff-ec3418681f0eed4be5fe5115e6f5918bcdc9eed729c97adf0f86b925853744b7L1-L2): Removed unused `using` directive (`ErrorOr`).
* [`src/Domain/Heroes/PowerLevelUpdatedEvent.cs`](diffhunk://#diff-6a63ad0b2c8159894f9d8acede76b07a40dc3a125aac82e2a9aa23ed7d3dd696L1-R1): Removed unused `using` directives (`ErrorOr`, `SSW.CleanArchitecture.Domain.Common.EventualConsistency`, and `SSW.CleanArchitecture.Domain.Common.Interfaces`).
* [`src/Domain/Heroes/TeamByIdSpec.cs`](diffhunk://#diff-999b172b6decf002a6a38acaf5b6ffb1435d86dae0b1e177a795415b7cc76ac0L1-R3): Removed unused `using` directive (`Ardalis.Specification`).
* [`src/Domain/Teams/Mission.cs`](diffhunk://#diff-e86b86e8d9c61a37430fe20b10f36babbf758234004a90a86dc6327491fd1a49L1-R1): Removed unused `using` directive (`Vogen`).
* [`src/Domain/Teams/MissionErrors.cs`](diffhunk://#diff-f193d9063984b025b5d1bdd175763baaeb8246ca458c17eea4cc34ea12d88b4fL1-L2): Removed unused `using` directive (`ErrorOr`).
* [`src/Domain/Teams/Team.cs`](diffhunk://#diff-2d226224d80d8dd6220ddfe88798da1a3734a838c0a6fb158bdbf362cb0f6159L2): Removed unused `using` directive (`Vogen`).
* [`src/Domain/Teams/TeamByIdSpec.cs`](diffhunk://#diff-14ecab4f2e228e62172919cfc2be44f78aa7396a82a9a91ae517d577c4630b80L1-R3): Removed unused `using` directive (`Ardalis.Specification`).
* [`src/Domain/Teams/TeamErrors.cs`](diffhunk://#diff-31c63694c2712f7a281aa6d3368e1946ba42cff5e69ad2a79e545c9eee2fd430L1-L2): Removed unused `using` directive (`ErrorOr`).
* [`src/Infrastructure/Middleware/EventualConsistencyMiddleware.cs`](diffhunk://#diff-e0ad92588aaba801d42f92944137aa9ef2f26fd6f92d2ec0fadbb9cf9599e3d1L4-L8): Removed unused `using` directives (`Microsoft.EntityFrameworkCore.Storage` and `System.Transactions`).
* [`tools/MigrationService/Worker.cs`](diffhunk://#diff-5c639244405f38f32c75919dfc1b340047fd664c1c4b6a175eee0beb1071de80L2): Removed unused `using` directive (`OpenTelemetry.Trace`).

### Addition of Global Using Directives:

* [`src/Domain/GlobalUsings.cs`](diffhunk://#diff-de0b1ddd0263f896a27b81e78a19e3f067f3244cfef106a9cd34329d595ec1acR3-R11): Added global using directives for `Ardalis.Specification` and `Vogen`.

> 3. Did you do pair or mob programming?

No