### PR TITLE
:recycle: add NoWarn for common code style use cases

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,5 +10,12 @@
         <AnalysisMode>Recommended</AnalysisMode>
         
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    </PropertyGroup>
+
+        <!-- Disable whitespace rule -->
+        <NoWarn>$(NoWarn);IDE0055</NoWarn>
+
+        <!-- Disable "must have curly braces for if/else" -->
+        <NoWarn>$(NoWarn);IDE0011</NoWarn>
+
+</PropertyGroup>
 </Project>


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Using the latest and greatest code analyzers is excellent, however there are a couple of code warnings that, in my opinion, we should be more lenient with:

![image](https://github.com/user-attachments/assets/9e5ef0cf-4391-46b4-a3f4-844f1849d5d0)
**Figure: Single command `else` statements are fairly common.**

![image](https://github.com/user-attachments/assets/3296bf0a-86b7-48e3-806a-cdfd93dfb458)
**Figure: developers will often want to add whitespace for readability**

> 2. What was changed?

- Add explicit `NoWarn` for these 2 warnings in `Directory.Build.Props`:

```
<!-- Disable whitespace rule -->
<NoWarn>$(NoWarn);IDE0055</NoWarn>

<!-- Disable "must have curly braces for if/else" -->
<NoWarn>$(NoWarn);IDE0011</NoWarn>
```

> 3. Did you do pair or mob programming?

✏️ 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
