### PR TITLE
👷 Fix log4brains publish

### DIFF
--- a/.github/workflows/publish-log4brains.yml
+++ b/.github/workflows/publish-log4brains.yml
@@ -3,6 +3,7 @@ name: Publish Log4brains
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch: # Add this line to allow manual triggering
 
 jobs:
   build-and-publish:
@@ -25,9 +26,9 @@ jobs:
           log4brains build --basePath /${GITHUB_REPOSITORY#*/}
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.6.9
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: .log4brains/out
-          TARGET_FOLDER: ''
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: .log4brains/out
+          target-folder: ''


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for publishing Log4brains. The changes primarily focus on adding manual triggering capabilities and updating the deployment action version.

Improvements to workflow configuration:

* [`.github/workflows/publish-log4brains.yml`](diffhunk://#diff-4ac665e28c3b53aecd510cf3e9cb851e01c4a42b0e34546d8c6afdcc1599cf5aR6): Added `workflow_dispatch` to allow manual triggering of the workflow.

Updates to deployment action:

* [`.github/workflows/publish-log4brains.yml`](diffhunk://#diff-4ac665e28c3b53aecd510cf3e9cb851e01c4a42b0e34546d8c6afdcc1599cf5aL28-R34): Updated `JamesIves/github-pages-deploy-action` from version `v4.6.9` to `v4.7.3` and adjusted the input parameters to match the new version's requirements.