### PR TITLE
⬆️ Update Nuget Packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,6 @@
     <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" />
     <PackageVersion Include="MediatR" Version="12.5.0"/>
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
-    <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.1.0" />
     <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
     <PackageVersion Include="Azure.Identity" Version="1.13.0" />
-    <PackageVersion Include="Bogus" Version="35.6.1" />
+    <PackageVersion Include="Bogus" Version="35.6.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="Scalar.AspNetCore" Version="2.1.6" />
     <PackageVersion Include="Testcontainers" Version="4.3.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.3.0" />
-    <PackageVersion Include="Vogen" Version="7.0.0" />
+    <PackageVersion Include="Vogen" Version="7.0.3" />
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="ErrorOr" Version="2.0.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" />
-    <PackageVersion Include="MediatR" Version="12.4.1" />
+    <PackageVersion Include="MediatR" Version="12.5.0"/>
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,58 +3,58 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Ardalis.Specification" Version="9.0.1"/>
-    <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.0.1"/>
-    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0"/>
-    <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="9.0.0"/>
-    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0"/>
-    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0"/>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0"/>
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.1.0"/>
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.1.0"/>
-    <PackageVersion Include="AwesomeAssertions" Version="8.0.2"/>
-    <PackageVersion Include="Azure.Identity" Version="1.13.0"/>
-    <PackageVersion Include="Bogus" Version="35.6.1"/>
+    <PackageVersion Include="Ardalis.Specification" Version="9.0.1" />
+    <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.0.1" />
+    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.1.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.13.0" />
+    <PackageVersion Include="Bogus" Version="35.6.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3"/>
-    <PackageVersion Include="ErrorOr" Version="2.0.1"/>
-    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0"/>
-    <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0"/>
-    <PackageVersion Include="MediatR" Version="12.4.1"/>
-    <PackageVersion Include="MediatR.Contracts" Version="2.0.1"/>
-    <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.7"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.2"/>
+    <PackageVersion Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3" />
+    <PackageVersion Include="ErrorOr" Version="2.0.1" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+    <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" />
+    <PackageVersion Include="MediatR" Version="12.4.1" />
+    <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
+    <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2"/>
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.2"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2"/>
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2"/>
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0"/>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-    <PackageVersion Include="NetArchTest.Rules" Version="1.3.2"/>
-    <PackageVersion Include="NSubstitute" Version="5.3.0"/>
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0"/>
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0"/>
-    <PackageVersion Include="Polly" Version="8.5.0"/>
-    <PackageVersion Include="Respawn" Version="6.2.1"/>
-    <PackageVersion Include="Scalar.AspNetCore" Version="1.2.39"/>
-    <PackageVersion Include="Testcontainers" Version="4.0.0"/>
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.0.0"/>
-    <PackageVersion Include="Vogen" Version="7.0.0"/>
-    <PackageVersion Include="xunit.v3" Version="1.1.0"/>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageVersion Include="Polly" Version="8.5.0" />
+    <PackageVersion Include="Respawn" Version="6.2.1" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="1.2.39" />
+    <PackageVersion Include="Testcontainers" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.0.0" />
+    <PackageVersion Include="Vogen" Version="7.0.0" />
+    <PackageVersion Include="xunit.v3" Version="1.1.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,18 +26,18 @@
     <PackageVersion Include="MediatR" Version="12.5.0"/>
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2">
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.3"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3"/>
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.3"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3"/>
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.3.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3"/>
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
     <PackageVersion Include="Polly" Version="8.5.2" />
     <PackageVersion Include="Respawn" Version="6.2.1" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="1.2.39" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.1.6" />
     <PackageVersion Include="Testcontainers" Version="4.0.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.0.0" />
     <PackageVersion Include="Vogen" Version="7.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,12 +42,12 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
-    <PackageVersion Include="Polly" Version="8.5.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
+    <PackageVersion Include="Polly" Version="8.5.2" />
     <PackageVersion Include="Respawn" Version="6.2.1" />
     <PackageVersion Include="Scalar.AspNetCore" Version="1.2.39" />
     <PackageVersion Include="Testcontainers" Version="4.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,8 +50,8 @@
     <PackageVersion Include="Polly" Version="8.5.2" />
     <PackageVersion Include="Respawn" Version="6.2.1" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.1.6" />
-    <PackageVersion Include="Testcontainers" Version="4.0.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers" Version="4.3.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.3.0" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,23 +23,23 @@
     <PackageVersion Include="ErrorOr" Version="2.0.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" />
-    <PackageVersion Include="MediatR" Version="12.5.0"/>
+    <PackageVersion Include="MediatR" Version="12.5.0" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3"/>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.3"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3"/>
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.3"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3"/>
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.3.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
@@ -53,7 +53,7 @@
     <PackageVersion Include="Testcontainers" Version="4.0.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.0.0" />
     <PackageVersion Include="Vogen" Version="7.0.0" />
-    <PackageVersion Include="xunit.v3" Version="1.1.0" />
+    <PackageVersion Include="xunit.v3" Version="2.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
   </ItemGroup>
 </Project>

--- a/src/Application/Common/Behaviours/PerformanceBehaviour.cs
+++ b/src/Application/Common/Behaviours/PerformanceBehaviour.cs
@@ -17,7 +17,7 @@ public class PerformanceBehaviour<TRequest, TResponse>(
     {
         _timer.Start();
 
-        var response = await next();
+        var response = await next(cancellationToken);
 
         _timer.Stop();
 

--- a/src/Application/Common/Behaviours/UnhandledExceptionBehaviour.cs
+++ b/src/Application/Common/Behaviours/UnhandledExceptionBehaviour.cs
@@ -11,7 +11,7 @@ public class UnhandledExceptionBehaviour<TRequest, TResponse>(ILogger<TRequest> 
     {
         try
         {
-            return await next();
+            return await next(cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Application/Common/Behaviours/ValidationErrorOrResultBehaviour.cs
+++ b/src/Application/Common/Behaviours/ValidationErrorOrResultBehaviour.cs
@@ -11,12 +11,12 @@ public class ValidationErrorOrResultBehavior<TRequest, TResponse>(IValidator<TRe
         CancellationToken cancellationToken)
     {
         if (validator is null)
-            return await next();
+            return await next(cancellationToken);
 
         var validationResult = await validator.ValidateAsync(request, cancellationToken);
 
         if (validationResult.IsValid)
-            return await next();
+            return await next(cancellationToken);
 
         var errors = validationResult.Errors
             .ConvertAll(error => Error.Validation(

--- a/tests/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/tests/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit.v3"/>
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/tests/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Testcontainers" />
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="Polly" />
-    <PackageReference Include="Meziantou.Extensions.Logging.Xunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit.v3"/>
     <PackageReference Include="xunit.runner.visualstudio">


### PR DESCRIPTION
This pull request includes updates to package versions and improvements to the handling of cancellation tokens in several behaviors. The most important changes are listed below:

### Package Version Updates:
* Updated `AwesomeAssertions` to version 8.1.0 and `Bogus` to version 35.6.2 in `Directory.Packages.props`.
* Updated `MediatR` to version 12.5.0 and various `Microsoft` packages to new versions in `Directory.Packages.props`.
* Updated `OpenTelemetry` packages to the latest versions in `Directory.Packages.props`.
* Updated `Scalar.AspNetCore`, `Testcontainers`, `Testcontainers.MsSql`, `Vogen`, and `xunit.v3` to new versions in `Directory.Packages.props`.

### Code Improvements:
* Added `cancellationToken` to the `next` method calls in `PerformanceBehaviour`, `UnhandledExceptionBehaviour`, and `ValidationErrorOrResultBehaviour` to improve cancellation handling. [[1]](diffhunk://#diff-a66f73a457802c5bfe372ae18e337df036e4a5058f9591cb2a96cf397a28cc67L20-R20) [[2]](diffhunk://#diff-61d09f033bc4c28897d6543c2cc664708bfaad48c70ee5553cbc40ee82e1c947L14-R14) [[3]](diffhunk://#diff-6749bd35a27b4fbff1e9d735da4b45f5d5aa4b314b8c46fed692805dbf21f4b7L14-R19)

### Test Project Updates:
* Removed the `Meziantou.Extensions.Logging.Xunit` package reference from `WebApi.IntegrationTests.csproj`.