### PR TITLE
🚀 Update version to 2025.04.07

### DIFF
--- a/CleanArchitecture.nuspec
+++ b/CleanArchitecture.nuspec
@@ -3,7 +3,7 @@
   <metadata>
 
     <id>SSW.CleanArchitecture.Template</id>
-    <version>2025.03.03</version>
+    <version>2025.04.07</version>
     <title>SSW Clean Architecture Template</title>
     <authors>SSW</authors>
     <description>SSW Clean Architecture Solution Template for .NET.</description>
@@ -33,5 +33,4 @@
     <file src=".\**" target="content" exclude="**\bin\**;**\obj\**;**\.vs\**;**\.vscode\**;**\.git\**;**\.github\**;**\LICENSE;**\.idea\**;CODE_OF_CONDUCT.yml" />
     <file src=".\.github\**" target="content\.github" exclude="CODEOWNERS;settings.yml;workflows\package.yml;workflows\update-settings.yml" />
   </files>
-<!--foo-->
 </package>


### PR DESCRIPTION
This pull request includes updates to the `CleanArchitecture.nuspec` file, focusing on versioning and cleanup.

Version update:

* Updated the version number from `2025.03.03` to `2025.04.07` to reflect the latest release.

File cleanup:

* Removed an unnecessary comment (`<!--foo-->`) from the `CleanArchitecture.nuspec` file to maintain a clean and professional codebase.