### PR TITLE
⬆️ Update Aspire.Hosting and related packages to version 9.2.0 and 9.2.1; refactor drop-database command

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,9 @@
     <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.1.0" />
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.2.1" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.2.1" />
+    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.2.1" />
     <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
     <PackageVersion Include="Azure.Identity" Version="1.13.0" />
     <PackageVersion Include="Bogus" Version="35.6.2" />
@@ -33,8 +33,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />

--- a/tools/AppHost/AppHost.csproj
+++ b/tools/AppHost/AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.1.0"/>
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0"/>
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/tools/AppHost/Commands/SqlServerCommandExt.cs
+++ b/tools/AppHost/Commands/SqlServerCommandExt.cs
@@ -24,7 +24,7 @@ public static class SqlServerDatabaseCommandExt
 
                 return CommandResults.Success();
             },
-            null);
+            null); // Intentionally using 'null' for the command state resolver as this command does not require health status checks. Downstream code is expected to handle 'null' appropriately.
         return builder;
     }
 }

--- a/tools/AppHost/Commands/SqlServerCommandExt.cs
+++ b/tools/AppHost/Commands/SqlServerCommandExt.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using SqlServerDatabaseResource = Aspire.Hosting.ApplicationModel.SqlServerDatabaseResource;
 
 namespace AppHost.Commands;
 
@@ -11,9 +12,9 @@ public static class SqlServerDatabaseCommandExt
         builder.WithCommand(
             "drop-database",
             "Drop Database",
-            async context =>
+            async _ =>
             {
-                var connectionString = await builder.Resource.ConnectionStringExpression.GetValueAsync(default);
+                var connectionString = await builder.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
                 ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
                 var optionsBuilder = new DbContextOptionsBuilder<DbContext>();
@@ -23,15 +24,7 @@ public static class SqlServerDatabaseCommandExt
 
                 return CommandResults.Success();
             },
-            context =>
-            {
-                if (context.ResourceSnapshot.HealthStatus is HealthStatus.Healthy)
-                {
-                    return ResourceCommandState.Enabled;
-                }
-
-                return ResourceCommandState.Disabled;
-            });
+            null);
         return builder;
     }
 }


### PR DESCRIPTION
This pull request updates several package versions and simplifies the implementation of the `WithDropDatabaseCommand` method in the `SqlServerCommandExt` class. The most important changes include upgrading dependencies in `Directory.Packages.props`, updating the SDK version in `AppHost.csproj`, and refactoring the database command logic.

### Dependency Updates:
* Updated the versions of `Aspire.Hosting.AppHost`, `Aspire.Hosting.SqlServer`, and `Aspire.Microsoft.EntityFrameworkCore.SqlServer` packages from `9.1.0` to `9.2.1` in `Directory.Packages.props`.
* Updated the versions of `Microsoft.Extensions.Diagnostics.HealthChecks` and `Microsoft.Extensions.DependencyInjection.Abstractions` packages from `9.0.3` to `9.0.4` in `Directory.Packages.props`.
* Updated the SDK version in `AppHost.csproj` from `9.1.0` to `9.2.0`.

### Code Simplifications:
* Added a new `using` directive for `SqlServerDatabaseResource` in `SqlServerCommandExt.cs` to improve clarity.
* Refactored the `WithDropDatabaseCommand` method in `SqlServerCommandExt.cs`:
  - Changed the lambda parameter name from `context` to `_` for unused parameters.
  - Replaced the resource health status check logic with `null` for simplicity.