### PR TITLE
🚀 Bump version to 2025-07-02

### DIFF
--- a/CleanArchitecture.nuspec
+++ b/CleanArchitecture.nuspec
@@ -3,7 +3,7 @@
   <metadata>
 
     <id>SSW.CleanArchitecture.Template</id>
-    <version>2025.04.07</version>
+    <version>2025.07.02</version>
     <title>SSW Clean Architecture Template</title>
     <authors>SSW</authors>
     <description>SSW Clean Architecture Solution Template for .NET.</description>


### PR DESCRIPTION
This pull request includes a minor update to the `CleanArchitecture.nuspec` file. The change updates the version number of the `SSW.CleanArchitecture.Template` package from `2025.04.07` to `2025.07.02`.