### PR TITLE
⬆️ Update nuget packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Ardalis.Specification" Version="9.0.1" />
-    <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.0.1" />
+    <PackageVersion Include="Ardalis.Specification" Version="9.2.0"/>
+    <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0"/>
     <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
@@ -12,48 +12,51 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.3.1" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.3.2" />
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.3.1" />
-    <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.1.0"/>
     <PackageVersion Include="Azure.Identity" Version="1.13.0" />
-    <PackageVersion Include="Bogus" Version="35.6.2" />
+    <PackageVersion Include="Bogus" Version="35.6.3"/>
     <PackageVersion Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3" />
     <PackageVersion Include="ErrorOr" Version="2.0.1" />
-    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0"/>
     <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" />
-    <PackageVersion Include="MediatR" Version="12.5.0" />
+    <PackageVersion Include="MediatR" Version="13.0.0"/>
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.7"/>
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.7"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.1.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7"/>
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.7"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7"/>
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.7.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7"/>
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.0"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
-    <PackageVersion Include="Polly" Version="8.5.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0"/>
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0"/>
+    <PackageVersion Include="Polly" Version="8.6.2"/>
     <PackageVersion Include="Respawn" Version="6.2.1" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.1.6" />
-    <PackageVersion Include="Testcontainers" Version="4.3.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.3.0" />
-    <PackageVersion Include="Vogen" Version="7.0.3" />
-    <PackageVersion Include="xunit.v3" Version="2.0.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.6.7"/>
+    <PackageVersion Include="Testcontainers" Version="4.6.0"/>
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.6.0"/>
+    <PackageVersion Include="Vogen" Version="7.0.4"/>
+    <PackageVersion Include="xunit.v3" Version="3.0.0"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
   </ItemGroup>
 </Project>

--- a/tests/Architecture.Tests/Common/TestResultAssertions.cs
+++ b/tests/Architecture.Tests/Common/TestResultAssertions.cs
@@ -1,5 +1,6 @@
-using FluentAssertions.Execution;
-using FluentAssertions.Primitives;
+using AwesomeAssertions;
+using AwesomeAssertions.Execution;
+using AwesomeAssertions.Primitives;
 using System.Text;
 using TestResult = NetArchTest.Rules.TestResult;
 

--- a/tests/Architecture.Tests/Common/TestResultExtensions.cs
+++ b/tests/Architecture.Tests/Common/TestResultExtensions.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions.Execution;
+﻿using AwesomeAssertions.Execution;
 using TestResult = NetArchTest.Rules.TestResult;
 
 namespace SSW.CleanArchitecture.Architecture.UnitTests.Common;

--- a/tests/Architecture.Tests/GlobalUsings.cs
+++ b/tests/Architecture.Tests/GlobalUsings.cs
@@ -1,3 +1,3 @@
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using NetArchTest.Rules;
 global using Xunit;

--- a/tests/Domain.UnitTests/GlobalUsings.cs
+++ b/tests/Domain.UnitTests/GlobalUsings.cs
@@ -1,2 +1,2 @@
 global using Xunit;
-global using FluentAssertions;
+global using AwesomeAssertions;

--- a/tests/WebApi.IntegrationTests/GlobalUsings.cs
+++ b/tests/WebApi.IntegrationTests/GlobalUsings.cs
@@ -1,2 +1,2 @@
 global using Xunit;
-global using FluentAssertions;
+global using AwesomeAssertions;


### PR DESCRIPTION
⚠️ merged without review by @danielmackay 

This pull request updates package dependencies and replaces the `FluentAssertions` library with `AwesomeAssertions` across multiple test files. The most important changes include upgrading package versions to address compatibility and performance improvements, and refactoring test files to use the new assertion library.

### Package Updates:
* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L6-R60): Upgraded multiple package versions, including `Ardalis.Specification` (9.0.1 → 9.2.0), `AwesomeAssertions` (8.1.0 → 9.1.0), `MediatR` (12.5.0 → 13.0.0), and various `Microsoft` packages (e.g., `Microsoft.EntityFrameworkCore` 9.0.3 → 9.0.7). These updates ensure compatibility with newer features and improve stability.

### Assertion Library Replacement:
* [`tests/Architecture.Tests/Common/TestResultAssertions.cs`](diffhunk://#diff-23e4889f0749073f27cf9182b870a49d27f6daf1dd95cd121302f38d5216c27eL1-R3): Replaced `FluentAssertions` imports with `AwesomeAssertions` equivalents.
* [`tests/Architecture.Tests/Common/TestResultExtensions.cs`](diffhunk://#diff-16db0378eb51d2de8c3b63c5eb97519390351d405f6b16fd99e904b4905408f3L1-R1): Updated `FluentAssertions.Execution` to `AwesomeAssertions.Execution`.
* `tests/Architecture.Tests/GlobalUsings.cs`, `tests/Domain.UnitTests/GlobalUsings.cs`, and `tests/WebApi.IntegrationTests/GlobalUsings.cs`: Replaced global `FluentAssertions` imports with `AwesomeAssertions`. [[1]](diffhunk://#diff-623152dc0abb058aa4b53b6bdcc26027938494a6584c2a989dca2079348b77ffL1-R1) [[2]](diffhunk://#diff-6fd7c9c2bcdd022a1998889b98037f9d0f5e8477145507bc5ffbb07d724d00c5L2-R2)