### PR TITLE
✨ Rename variable for clarity in database initialization

### DIFF
--- a/tools/MigrationService/Worker.cs
+++ b/tools/MigrationService/Worker.cs
@@ -21,13 +21,13 @@ public class Worker(
             using var scope = serviceProvider.CreateScope();
             var environment = scope.ServiceProvider.GetRequiredService<IHostEnvironment>();
 
-            var warehouseInitializer = scope.ServiceProvider.GetRequiredService<ApplicationDbContextInitializer>();
-            await warehouseInitializer.EnsureDatabaseAsync(stoppingToken);
-            await warehouseInitializer.CreateSchemaAsync(true, stoppingToken);
+            var initializer = scope.ServiceProvider.GetRequiredService<ApplicationDbContextInitializer>();
+            await initializer.EnsureDatabaseAsync(stoppingToken);
+            await initializer.CreateSchemaAsync(true, stoppingToken);
 
             if (environment.IsDevelopment())
             {
-                await warehouseInitializer.SeedDataAsync(stoppingToken);
+                await initializer.SeedDataAsync(stoppingToken);
             }
 
             sw.Stop();


### PR DESCRIPTION
This pull request makes a minor refactor to the `Worker.cs` file in the migration service, improving code clarity by renaming a local variable for consistency.

* Refactored the local variable name from `warehouseInitializer` to `initializer` throughout the `ExecuteAsync` method in `Worker.cs` for improved clarity and consistency.