### PR TITLE
Fix/add async to add integration test base

### DIFF
--- a/tests/WebApi.IntegrationTests/Common/IntegrationTestBase.cs
+++ b/tests/WebApi.IntegrationTests/Common/IntegrationTestBase.cs
@@ -34,14 +34,14 @@ public abstract class IntegrationTestBase : IAsyncLifetime
     protected async Task AddAsync<TEntity>(TEntity entity)
         where TEntity : class
     {
-        await _dbContext.AddAsync(entity, CancellationToken);
+        _dbContext.Add(entity);
         await _dbContext.SaveChangesAsync(CancellationToken);
     }
 
     protected async Task AddRangeAsync<TEntity>(IEnumerable<TEntity> entities)
         where TEntity : class
     {
-        await _dbContext.AddRangeAsync(entities, CancellationToken);
+        _dbContext.AddRange(entities);
         await _dbContext.SaveChangesAsync(CancellationToken);
     }
 

--- a/tests/WebApi.IntegrationTests/Common/IntegrationTestBase.cs
+++ b/tests/WebApi.IntegrationTests/Common/IntegrationTestBase.cs
@@ -35,14 +35,14 @@ public abstract class IntegrationTestBase : IAsyncLifetime
         where TEntity : class
     {
         _dbContext.Add(entity);
-        await _dbContext.SaveChangesAsync(CancellationToken);
+        await SaveAsync();
     }
 
     protected async Task AddRangeAsync<TEntity>(IEnumerable<TEntity> entities)
         where TEntity : class
     {
         _dbContext.AddRange(entities);
-        await _dbContext.SaveChangesAsync(CancellationToken);
+        await SaveAsync();
     }
 
     protected async Task SaveAsync()


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ I was migrating my RecipeApi to CA template & accidentally used this piece of code
```csharp
//.. some other code in my CreateIngredientCommand.cs

await dbContext.Ingredients.AddAsync(ingredient, cancellationToken); // <- see here
await dbContext.SaveChangesAsync(cancellationToken);

// ..some other code
```
While reviewing my pr @lukecookssw left [this comment about AddAsync](https://github.com/SSW-FireBootCamp/SSWFireBootCamp.2025.Sydney.HarkiratSingh/pull/187#discussion_r2361463167)
<img width="938" height="818" alt="Screenshot 2025-09-19 at 12 24 09" src="https://github.com/user-attachments/assets/556b9966-eb03-45b9-866c-2a66ec1d779a" />
Figure: Luke's comment on my PR.

Then, I noticed the [IntegrationTestBase.cs](https://github.com/SSWConsulting/SSW.CleanArchitecture/blob/main/tests/WebApi.IntegrationTests/Common/IntegrationTestBase.cs) in the CA template is doing the same. So he asked me to raise the PR & tag @danielmackay. 

As @danielmackay is out of office today. I discussed with @AntPolkanov before raising the PR & he said it should be just `Add(entity);`


> 2. What was changed?

✏️ It was easy fix, just changed:
```csharp
 protected async Task AddAsync<TEntity>(TEntity entity)
        where TEntity : class
    {
        _dbContext.Add(entity); // <- see here the change
        await _dbContext.SaveChangesAsync(CancellationToken);
    }

    protected async Task AddRangeAsync<TEntity>(IEnumerable<TEntity> entities)
        where TEntity : class
    {
        _dbContext.AddRange(entities); // <- see here the change
        await _dbContext.SaveChangesAsync(CancellationToken);
    }
```
> 3. Did you do pair or mob programming?

✏️ 
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->

<img width="849" height="265" alt="Screenshot 2025-09-19 at 12 37 01" src="https://github.com/user-attachments/assets/996a8aae-1d27-4493-8347-6036aade4df7" />
Figure: All tests passing after the change.
