### PR TITLE
⬆️ Update package versions to 13.0.2 in AppHost and Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,15 +5,15 @@
   <ItemGroup>
     <PackageVersion Include="Ardalis.Specification" Version="9.3.1" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.3.1" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="9.5.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.AppService" Version="9.5.0-preview.1.25474.7" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="9.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="13.0.2" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppService" Version="13.0.2-preview.1.25603.5" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="13.0.2" />
     <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.5.0" />
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="9.5.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.0.2" />
+    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.2" />
     <PackageVersion Include="AwesomeAssertions" Version="9.2.0" />
     <PackageVersion Include="Azure.Identity" Version="1.13.0" />
     <PackageVersion Include="Bogus" Version="35.6.4" />
@@ -35,11 +35,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />

--- a/tools/AppHost/AppHost.csproj
+++ b/tools/AppHost/AppHost.csproj
@@ -1,6 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.0" />
+<Project Sdk="Aspire.AppHost.Sdk/13.0.2">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
﻿> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Release of .NET 10

> 2. What was changed?
 
This pull request updates several package dependencies to their latest versions, primarily focusing on the Aspire and Microsoft.Extensions libraries. The main goal is to ensure the project uses the most recent features, improvements, and security updates from these libraries.

Dependency version upgrades:

**Aspire package updates:**
* Updated `Aspire.Hosting.Azure.ApplicationInsights`, `Aspire.Hosting.Azure.AppService`, `Aspire.Hosting.Azure.Sql`, `Aspire.Hosting.AppHost`, and `Aspire.Microsoft.EntityFrameworkCore.SqlServer` to version `13.0.2` (or `13.0.2-preview.1.25603.5` for AppService), replacing previous `9.5.0` versions. (`Directory.Packages.props`, `tools/AppHost/AppHost.csproj`) [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L8-R16) [[2]](diffhunk://#diff-cda82b6742843f6c1767221e433612d9fa582a55058b1f5ee6a5563151ba4656L1-R1)

**Microsoft.Extensions library updates:**
* Upgraded `Microsoft.Extensions.Diagnostics.HealthChecks`, `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Hosting`, and `Microsoft.Extensions.Logging.Abstractions` from `9.0.9` to `9.0.11`. (`Directory.Packages.props`)

These updates help keep the codebase current and compatible with the latest features and bug fixes in the .NET ecosystem.

> 3. Did you do pair or mob programming?

No
<!-- E.g. I worked with @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
