### PR TITLE
📝 Link SQL exceptions ADR to the SSW rule

### DIFF
--- a/docs/adr/20241118-produce-useful-sql-server-exceptions.md
+++ b/docs/adr/20241118-produce-useful-sql-server-exceptions.md
@@ -19,6 +19,8 @@ EF Core typically throws `DbUpdateException` which doesn’t tell you much until
 
 Chosen option: "Option 1", because it does what we need and is far better than the default EF Core exceptions.
 
+See the SSW Rule [Do you use strongly typed database exceptions?](https://www.ssw.com.au/rules/strongly-typed-database-exceptions) for the wider guidance behind this decision.
+
 ## Pros and Cons of the Options
 
 ### Option 1 - EntityFrameworkCore.Exceptions.SqlServer
@@ -28,4 +30,4 @@ Chosen option: "Option 1", because it does what we need and is far better than t
 
 ## Links
 
-- https://youtube.com/watch?v=QKwZlWvfh-o&si=yVnd5a7CVZaSV_Gr
+- https://www.ssw.com.au/rules/strongly-typed-database-exceptions


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ The SSW rule [Do you use strongly typed database exceptions?](https://www.ssw.com.au/rules/strongly-typed-database-exceptions) now covers this topic, so the ADR should point at it.

> 2. What was changed?

✏️ Added the rule link to the Decision Outcome and the Links section of `docs/adr/20241118-produce-useful-sql-server-exceptions.md`. Removed the YouTube link, since the rule now covers that ground.

> 3. Did you do pair or mob programming?

✏️ N/A