### PR TITLE
🔧 Publish the ADR site with the official Pages actions

### DIFF
--- a/.github/workflows/publish-log4brains.yml
+++ b/.github/workflows/publish-log4brains.yml
@@ -5,14 +5,27 @@ on:
     branches: [ "main" ]
   workflow_dispatch: # Add this line to allow manual triggering
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Pages rejects overlapping deployments, so queue them instead of cancelling an
+# in-flight one and leaving the site half-published.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          persist-credentials: false # required by JamesIves/github-pages-deploy-action
           fetch-depth: 0 # required by Log4brains to work correctly (needs the whole Git history)
 
       - name: Install Node
@@ -20,14 +33,19 @@ jobs:
         with:
           node-version: "21"
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
       - name: Install and Build Log4brains
         run: |
           npm install -g log4brains
           log4brains build --basePath /${GITHUB_REPOSITORY#*/}
 
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          folder: .log4brains/out
-          target-folder: ''
+          path: .log4brains/out
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ The ADR site stopped updating. PR #630 merged, `Publish Log4brains` went green, `gh-pages` got the new commit, but https://sswconsulting.github.io/SSW.CleanArchitecture/ still serves the 12 June build.

The repo's Pages source is set to GitHub Actions (`build_type: workflow`), so only an `actions/deploy-pages` call publishes anything. The workflow was still pushing to the `gh-pages` branch with `JamesIves/github-pages-deploy-action`, and under that setting a branch push no longer triggers a Pages build. Last real Pages deployment: 2026-06-12.

> 2. What was changed?

✏️ `.github/workflows/publish-log4brains.yml` now uses the official chain:

- `actions/configure-pages@v6`, `actions/upload-pages-artifact@v5`, `actions/deploy-pages@v5` replace the `gh-pages` branch push
- added `permissions: pages: write` + `id-token: write` (required by `deploy-pages`)
- added the `github-pages` environment so the deployment URL shows on the run
- added a `pages` concurrency group, since Pages rejects overlapping deployments
- dropped `persist-credentials: false`, which only existed for the old action

The `gh-pages` branch becomes unused after this.

> 3. Did you do pair or mob programming?

✏️ N/A

## Test plan

- [ ] Merge, then confirm `Publish Log4brains` runs the Deploy to GitHub Pages step and reports a deployment URL
- [ ] `gh api repos/SSWConsulting/SSW.CleanArchitecture/pages/builds` shows a fresh build (currently stuck on 2026-06-12)
- [ ] The [SQL exceptions ADR](https://sswconsulting.github.io/SSW.CleanArchitecture/adr/20241118-produce-useful-sql-server-exceptions/) shows the SSW rule link from #630 and no YouTube link