### PR TITLE
📝 Link the ADRs to the relevant SSW rules

### DIFF
--- a/docs/adr/20230604-use-the-factory-pattern-to-create-aggregates.md
+++ b/docs/adr/20230604-use-the-factory-pattern-to-create-aggregates.md
@@ -26,6 +26,8 @@ Aggregate roots can be instantiated in a way that satisfies all the decision dri
 
 Chosen **Option 1. Factory Methods**, because it is the only option that meets all the decision drivers.
 
+See the SSW Rule [Do you encapsulate domain models in Domain-Driven Design?](https://www.ssw.com.au/rules/encapsulate-domain-models), which lists factory methods as one of the ways to keep an aggregate encapsulated.
+
 ## Consequences
 
 - Private constructors can be used to ensure that aggregates are always in a valid state
@@ -48,3 +50,9 @@ Chosen **Option 1. Factory Methods**, because it is the only option that meets a
 ### 3. `required init` properties
 
 - ❌ Properties need to be passed to constructors to ensure they are in a valid state on object creation.  Can't use `required init` properties as they then become unmodifiable
+
+## Links
+
+- [Do you encapsulate domain models in Domain-Driven Design?](https://www.ssw.com.au/rules/encapsulate-domain-models)
+- [Do you understand the difference between anemic and rich domain models?](https://www.ssw.com.au/rules/anemic-vs-rich-domain-models)
+- [Do you know when to use value objects?](https://www.ssw.com.au/rules/when-to-use-value-objects)

--- a/docs/adr/20230612-use-ef-core-and-specifications-in-commands-and-queries.md
+++ b/docs/adr/20230612-use-ef-core-and-specifications-in-commands-and-queries.md
@@ -65,7 +65,5 @@ See the SSW Rule [Do you use the Specification pattern in your software design?]
 ## Links
 
 - [Do you use the Specification pattern in your software design?](https://www.ssw.com.au/rules/use-specification-pattern)
-- [Do you use the repository pattern for data access?](https://www.ssw.com.au/rules/do-you-use-the-repository-pattern-for-data-access)
 - [Do you keep business logic out of the presentation layer?](https://www.ssw.com.au/rules/keep-business-logic-out-of-the-presentation-layer)
 - [Do you optimize your EF Core queries?](https://www.ssw.com.au/rules/optimize-ef-core-queries)
-- [Do you only project properties you need?](https://www.ssw.com.au/rules/only-project-properties-you-need)

--- a/docs/adr/20230612-use-ef-core-and-specifications-in-commands-and-queries.md
+++ b/docs/adr/20230612-use-ef-core-and-specifications-in-commands-and-queries.md
@@ -26,6 +26,10 @@ The current approach of using Repositories and Specifications for queries did no
 
 Chosen **Option 2 - EF Core + Specifications**, because it provides a good balance of query reusability, efficient querying of the DB, and allows for aggregate roots to be loaded in a consistent way.
 
+See the SSW Rule [Do you use the Specification pattern in your software design?](https://www.ssw.com.au/rules/use-specification-pattern) for the wider guidance behind this decision.
+
+We deliberately step away from [Do you use the repository pattern for data access?](https://www.ssw.com.au/rules/do-you-use-the-repository-pattern-for-data-access). `DbContext` already gives us the abstraction that rule is after, and a repository layered on top of it blocks efficient projection onto DTOs.
+
 ### Consequences
 
 - ❌ Unable to unit test commands and queries.  Will need to leverage integration tests due to EF Core.
@@ -59,3 +63,11 @@ Chosen **Option 2 - EF Core + Specifications**, because it provides a good balan
 - ❌ Cannot be unit tested
 - ❌ Commands/Queries Cannot be unit tested
 - ❌ Dependency on EF Core added to Application
+
+## Links
+
+- [Do you use the Specification pattern in your software design?](https://www.ssw.com.au/rules/use-specification-pattern)
+- [Do you use the repository pattern for data access?](https://www.ssw.com.au/rules/do-you-use-the-repository-pattern-for-data-access)
+- [Do you use the Mediator pattern with CQRS?](https://www.ssw.com.au/rules/use-the-mediator-pattern-with-cqrs)
+- [Do you optimize your EF Core queries?](https://www.ssw.com.au/rules/optimize-ef-core-queries)
+- [Do you only project properties you need?](https://www.ssw.com.au/rules/only-project-properties-you-need)

--- a/docs/adr/20230612-use-ef-core-and-specifications-in-commands-and-queries.md
+++ b/docs/adr/20230612-use-ef-core-and-specifications-in-commands-and-queries.md
@@ -28,8 +28,6 @@ Chosen **Option 2 - EF Core + Specifications**, because it provides a good balan
 
 See the SSW Rule [Do you use the Specification pattern in your software design?](https://www.ssw.com.au/rules/use-specification-pattern) for the wider guidance behind this decision.
 
-We deliberately step away from [Do you use the repository pattern for data access?](https://www.ssw.com.au/rules/do-you-use-the-repository-pattern-for-data-access). `DbContext` already gives us the abstraction that rule is after, and a repository layered on top of it blocks efficient projection onto DTOs.
-
 ### Consequences
 
 - ❌ Unable to unit test commands and queries.  Will need to leverage integration tests due to EF Core.
@@ -68,6 +66,6 @@ We deliberately step away from [Do you use the repository pattern for data acces
 
 - [Do you use the Specification pattern in your software design?](https://www.ssw.com.au/rules/use-specification-pattern)
 - [Do you use the repository pattern for data access?](https://www.ssw.com.au/rules/do-you-use-the-repository-pattern-for-data-access)
-- [Do you use the Mediator pattern with CQRS?](https://www.ssw.com.au/rules/use-the-mediator-pattern-with-cqrs)
+- [Do you keep business logic out of the presentation layer?](https://www.ssw.com.au/rules/keep-business-logic-out-of-the-presentation-layer)
 - [Do you optimize your EF Core queries?](https://www.ssw.com.au/rules/optimize-ef-core-queries)
 - [Do you only project properties you need?](https://www.ssw.com.au/rules/only-project-properties-you-need)

--- a/docs/adr/20230612-use-log4brains-to-manage-the-adrs.md
+++ b/docs/adr/20230612-use-log4brains-to-manage-the-adrs.md
@@ -20,3 +20,10 @@ Which tool(s) should we use to manage these records?
 ## Decision Outcome
 
 Chosen option: "Log4brains", because it includes the features of all the other tools, and even more.
+
+See the SSW Rule [Do you use Architectural Decision Records (ADRs)?](https://www.ssw.com.au/rules/architectural-decision-records), which also recommends Log4brains.
+
+## Links
+
+- [Do you use Architectural Decision Records (ADRs)?](https://www.ssw.com.au/rules/architectural-decision-records)
+- [Do you make awesome documentation?](https://www.ssw.com.au/rules/awesome-documentation)

--- a/docs/adr/20230612-use-markdown-architectural-decision-records.md
+++ b/docs/adr/20230612-use-markdown-architectural-decision-records.md
@@ -20,6 +20,8 @@ Which format and structure should these records follow?
 
 ## Decision Outcome
 
+See the SSW Rule [Do you use Architectural Decision Records (ADRs)?](https://www.ssw.com.au/rules/architectural-decision-records) for the fields an ADR should capture.
+
 Chosen option: "MADR 2.1.2 with Log4brains patch", because
 
 - Implicit assumptions should be made explicit.
@@ -40,3 +42,5 @@ The "Log4brains patch" performs the following modifications to the original temp
 ## Links
 
 - Relates to [Use Log4brains to manage the ADRs](20230612-use-log4brains-to-manage-the-adrs.md)
+- [Do you use Architectural Decision Records (ADRs)?](https://www.ssw.com.au/rules/architectural-decision-records)
+- [Do you make awesome documentation?](https://www.ssw.com.au/rules/awesome-documentation)

--- a/docs/adr/20230612-use-markdown-architectural-decision-records.md
+++ b/docs/adr/20230612-use-markdown-architectural-decision-records.md
@@ -20,8 +20,6 @@ Which format and structure should these records follow?
 
 ## Decision Outcome
 
-See the SSW Rule [Do you use Architectural Decision Records (ADRs)?](https://www.ssw.com.au/rules/architectural-decision-records) for the fields an ADR should capture.
-
 Chosen option: "MADR 2.1.2 with Log4brains patch", because
 
 - Implicit assumptions should be made explicit.
@@ -38,6 +36,8 @@ The "Log4brains patch" performs the following modifications to the original temp
 - Change the ADR filenames format (`NNN-adr-name` becomes `YYYYMMDD-adr-name`), to avoid conflicts during Git merges.
 - Add a `draft` status, to enable collaborative writing.
 - Add a `Tags` field.
+
+See the SSW Rule [Do you use Architectural Decision Records (ADRs)?](https://www.ssw.com.au/rules/architectural-decision-records) for the fields an ADR should capture.
 
 ## Links
 

--- a/docs/adr/20230810-move-specifications-to-the-domain.md
+++ b/docs/adr/20230810-move-specifications-to-the-domain.md
@@ -28,6 +28,8 @@ The primary use cases for specifications are to:
 
 Chosen option: **Option 1 - Store Specfications in the Domain Layer**, as it allows us to move more business logic to the Domain Layer in a persistent ignorant way, and makes it easier to keep the specs up to date when the aggregate root changes.
 
+See the SSW Rule [Do you use the Specification pattern in your software design?](https://www.ssw.com.au/rules/use-specification-pattern) for the wider guidance behind this decision. [Do you keep your domain layer independent of the data access concerns?](https://www.ssw.com.au/rules/keep-your-domain-layer-independent-of-the-data-access-concerns) is where the persistence ignorance decision driver comes from.
+
 ## Pros and Cons of the Options
 
 ### Option 1 - Store Specfications in the Domain Layer
@@ -40,3 +42,9 @@ Chosen option: **Option 1 - Store Specfications in the Domain Layer**, as it all
 
 - ✅ Keep Domain Layer cleaner
 - ❌ Specs used to load aggregate roots are now stored in a separate location from the aggregates they are used to load.  This makes it harder to keep the specs up to date when the aggregate root changes 
+
+## Links
+
+- [Do you use the Specification pattern in your software design?](https://www.ssw.com.au/rules/use-specification-pattern)
+- [Do you keep your domain layer independent of the data access concerns?](https://www.ssw.com.au/rules/keep-your-domain-layer-independent-of-the-data-access-concerns)
+- [Do you encapsulate domain models in Domain-Driven Design?](https://www.ssw.com.au/rules/encapsulate-domain-models)

--- a/docs/adr/20231212-subcutaneous-tests-should-target-webapi-layer.md
+++ b/docs/adr/20231212-subcutaneous-tests-should-target-webapi-layer.md
@@ -25,6 +25,8 @@ Previously, the Subcutaneous tests were targeting the Application Layer. This wa
 
 Chosen option: "Option 2: Change Subcutaneous tests to target the WebApi Layer", because the subcutaneous tests should be testing as much of the stack as possible.  There is no downside to this option.
 
+See the SSW Rule [Do you use subcutaneous tests?](https://www.ssw.com.au/rules/subcutaneous-tests) for what these tests are and why they sit just below the UI.
+
 ## Pros and Cons of the Options
 
 ### Option 1: Leave the Subcutaneous tests targeting the Application Layer
@@ -42,3 +44,10 @@ In this option specifically we've decided hardcode the API routes as opposed to 
 - ✅ Serialization tested
 - ✅ Web Authentication/Authorization tested
 - ⚠️ Some contract testing (routes only)
+
+## Links
+
+- [Do you use subcutaneous tests?](https://www.ssw.com.au/rules/subcutaneous-tests)
+- [Do you use IApiMarker with WebApplicationFactory?](https://www.ssw.com.au/rules/use-iapimarker-with-webapplicationfactory)
+- [Do you know the best test framework to run your integration tests?](https://www.ssw.com.au/rules/the-best-test-framework-to-run-your-integration-tests)
+- [Do you understand the "testing pyramid" models?](https://www.ssw.com.au/rules/testing-pyramid)

--- a/docs/adr/20231212-subcutaneous-tests-should-target-webapi-layer.md
+++ b/docs/adr/20231212-subcutaneous-tests-should-target-webapi-layer.md
@@ -49,5 +49,5 @@ In this option specifically we've decided hardcode the API routes as opposed to 
 
 - [Do you use subcutaneous tests?](https://www.ssw.com.au/rules/subcutaneous-tests)
 - [Do you use IApiMarker with WebApplicationFactory?](https://www.ssw.com.au/rules/use-iapimarker-with-webapplicationfactory)
-- [Do you know the best test framework to run your integration tests?](https://www.ssw.com.au/rules/the-best-test-framework-to-run-your-integration-tests)
+- [Do you know the most popular unit and integration testing frameworks for .NET applications?](https://www.ssw.com.au/rules/testing-tools)
 - [Do you understand the "testing pyramid" models?](https://www.ssw.com.au/rules/testing-pyramid)

--- a/docs/adr/20240219-revisit-openapi-document-generation.md
+++ b/docs/adr/20240219-revisit-openapi-document-generation.md
@@ -30,7 +30,7 @@ Enum generation needs to also be considered as this is often a painpoint
 
 Chosen option: "NSwag (runtime only)", because the NSwag repo is more active than the Swashbuckle one. The removal of NSwag.MSBuild also improved build times. 
 
-See the SSW Rule [Do you document your Web API?](https://www.ssw.com.au/rules/do-you-document-your-webapi) for the SSW position on generated API documentation.
+This decision was later revisited. See [Use .NET OpenAPI and Scalar over NSwag and Swagger](20241023-use-net-openapi-and-scalar-over-nswag-and-swagger.md).
 
 ### Consequences <!-- optional -->
 
@@ -71,5 +71,6 @@ Same as option 1 but without MSBuild step
 
 ## Links
 
+- Superseded by [Use .NET OpenAPI and Scalar over NSwag and Swagger](20241023-use-net-openapi-and-scalar-over-nswag-and-swagger.md)
 - [Do you document your Web API?](https://www.ssw.com.au/rules/do-you-document-your-webapi)
 - [Do you generate API clients?](https://www.ssw.com.au/rules/generate-api-clients)

--- a/docs/adr/20240219-revisit-openapi-document-generation.md
+++ b/docs/adr/20240219-revisit-openapi-document-generation.md
@@ -30,6 +30,8 @@ Enum generation needs to also be considered as this is often a painpoint
 
 Chosen option: "NSwag (runtime only)", because the NSwag repo is more active than the Swashbuckle one. The removal of NSwag.MSBuild also improved build times. 
 
+See the SSW Rule [Do you document your Web API?](https://www.ssw.com.au/rules/do-you-document-your-webapi) for the SSW position on generated API documentation.
+
 ### Consequences <!-- optional -->
 
 - ✅ Clients that generate code can use nswag to generate their own code with a nice enum experience
@@ -67,4 +69,7 @@ Same as option 1 but without MSBuild step
 - ❌ Now serving a runtime generated file instead of a static file
 - ❌ NSwag still uses Newtonsoft.Json internally - although it is moving to System.Text.Json in the next major version v15
 
+## Links
 
+- [Do you document your Web API?](https://www.ssw.com.au/rules/do-you-document-your-webapi)
+- [Do you generate API clients?](https://www.ssw.com.au/rules/generate-api-clients)

--- a/docs/adr/20240404-use-domain-driven-design-tactical-patterns.md
+++ b/docs/adr/20240404-use-domain-driven-design-tactical-patterns.md
@@ -24,6 +24,8 @@ We would like to default to using DDD in the template and provide a good example
 
 Chosen option: "Option 2 - Rich Domain Model with DDD", because it helps set developers up for success when building complex applications.  It's easier to go from a rich domain model to an anemic domain model than the other way around.
 
+See the SSW Rule [Do you understand the difference between anemic and rich domain models?](https://www.ssw.com.au/rules/anemic-vs-rich-domain-models) for the wider guidance behind this decision.
+
 ### Consequences <!-- optional -->
 
 - Need to create a new Domain model to show the usefulness of DDD.  This will require most layers to be rebuilt.
@@ -41,3 +43,10 @@ Chosen option: "Option 2 - Rich Domain Model with DDD", because it helps set dev
 - ✅ More flexible for complex applications
 - ❌ Overkill for trivial applications
 - ❌ More complex to understand
+
+## Links
+
+- [Do you understand the difference between anemic and rich domain models?](https://www.ssw.com.au/rules/anemic-vs-rich-domain-models)
+- [Do you encapsulate domain models in Domain-Driven Design?](https://www.ssw.com.au/rules/encapsulate-domain-models)
+- [Do you use ubiquitous language?](https://www.ssw.com.au/rules/ubiquitous-language)
+- [Clean Architecture - Do you know the main principles?](https://www.ssw.com.au/rules/clean-architecture)

--- a/docs/adr/20240404-use-domain-driven-design-tactical-patterns.md
+++ b/docs/adr/20240404-use-domain-driven-design-tactical-patterns.md
@@ -49,4 +49,3 @@ See the SSW Rule [Do you understand the difference between anemic and rich domai
 - [Do you understand the difference between anemic and rich domain models?](https://www.ssw.com.au/rules/anemic-vs-rich-domain-models)
 - [Do you encapsulate domain models in Domain-Driven Design?](https://www.ssw.com.au/rules/encapsulate-domain-models)
 - [Do you use ubiquitous language?](https://www.ssw.com.au/rules/ubiquitous-language)
-- [Clean Architecture - Do you know the main principles?](https://www.ssw.com.au/rules/clean-architecture)

--- a/docs/adr/20240415-replace-string-length-constraints-with-better-business-rules.md
+++ b/docs/adr/20240415-replace-string-length-constraints-with-better-business-rules.md
@@ -29,7 +29,7 @@ and instead opt to add more rules which adhere more to the example business logi
 Chosen option: "Replace string length constraints with non-technical requirement", because we want to
 keep the example of guard clauses in the code.
 
-See the SSW Rule [Do you keep your domain layer independent of the data access concerns?](https://www.ssw.com.au/rules/keep-your-domain-layer-independent-of-the-data-access-concerns). Dropping arbitrary column lengths is that same principle applied to string constraints.
+Related SSW Rule: [Do you keep your domain layer independent of the data access concerns?](https://www.ssw.com.au/rules/keep-your-domain-layer-independent-of-the-data-access-concerns). That rule keeps length and validation constraints but moves them into the EF Core configuration. This ADR goes further and drops the arbitrary ones altogether, which is why "no example of linking domain constraints to infrastructure implementation" is listed below as a downside.
 
 ## Pros and Cons of the Options <!-- optional -->
 

--- a/docs/adr/20240415-replace-string-length-constraints-with-better-business-rules.md
+++ b/docs/adr/20240415-replace-string-length-constraints-with-better-business-rules.md
@@ -29,6 +29,8 @@ and instead opt to add more rules which adhere more to the example business logi
 Chosen option: "Replace string length constraints with non-technical requirement", because we want to
 keep the example of guard clauses in the code.
 
+See the SSW Rule [Do you keep your domain layer independent of the data access concerns?](https://www.ssw.com.au/rules/keep-your-domain-layer-independent-of-the-data-access-concerns). Dropping arbitrary column lengths is that same principle applied to string constraints.
+
 ## Pros and Cons of the Options <!-- optional -->
 
 ### 1. Replace string length constraints with non-technical requirement
@@ -49,3 +51,8 @@ keep the example of guard clauses in the code.
 - ❌ Shared constraint values for different entities / across aggregate root
 - ❌ Template starts with limit to string length which might not be needed / different value needed for different projects
 
+## Links
+
+- [Do you keep your domain layer independent of the data access concerns?](https://www.ssw.com.au/rules/keep-your-domain-layer-independent-of-the-data-access-concerns)
+- [Do you encapsulate domain models in Domain-Driven Design?](https://www.ssw.com.au/rules/encapsulate-domain-models)
+- [Do you understand the difference between anemic and rich domain models?](https://www.ssw.com.au/rules/anemic-vs-rich-domain-models)

--- a/docs/adr/20240605-use-minimal-api-typed-results.md
+++ b/docs/adr/20240605-use-minimal-api-typed-results.md
@@ -38,7 +38,7 @@ This inconsistency, makes integrating with our APIs difficult.
 
 Chosen option: "Option 2 - Use TypedResults", because it allows us to guarantee our APIs return what they say they do.
 
-See the SSW Rule [Do you return the correct response code?](https://www.ssw.com.au/rules/do-you-return-the-correct-response-code). `TypedResults` is how we enforce that at compile time instead of by convention.
+See the SSW Rule [Do you return the correct response code?](https://www.ssw.com.au/rules/do-you-return-the-correct-response-code). Picking the right code is still on the developer, but `TypedResults` makes the compiler check that the advertised codes match the ones the handler can actually return.
 
 ### Consequences <!-- optional -->
 

--- a/docs/adr/20240605-use-minimal-api-typed-results.md
+++ b/docs/adr/20240605-use-minimal-api-typed-results.md
@@ -38,6 +38,8 @@ This inconsistency, makes integrating with our APIs difficult.
 
 Chosen option: "Option 2 - Use TypedResults", because it allows us to guarantee our APIs return what they say they do.
 
+See the SSW Rule [Do you return the correct response code?](https://www.ssw.com.au/rules/do-you-return-the-correct-response-code). `TypedResults` is how we enforce that at compile time instead of by convention.
+
 ### Consequences <!-- optional -->
 
 - Dependency on additional nuget packages
@@ -96,3 +98,6 @@ group
 ## Links <!-- optional -->
 
 - https://www.dandoescode.com/blog/minimal-apis-typed-results-and-open-api
+- [Do you return the correct response code?](https://www.ssw.com.au/rules/do-you-return-the-correct-response-code)
+- [Do you use Minimal APIs over Controllers?](https://www.ssw.com.au/rules/minimal-apis)
+- [Do you document your Web API?](https://www.ssw.com.au/rules/do-you-document-your-webapi)

--- a/docs/adr/20240605-use-results-pattern-over-exceptions.md
+++ b/docs/adr/20240605-use-results-pattern-over-exceptions.md
@@ -69,7 +69,6 @@ The result pattern could be implemented via:
 
 - [Do you use the result pattern?](https://www.ssw.com.au/rules/do-you-use-the-result-pattern)
 - [Do you catch exceptions precisely?](https://www.ssw.com.au/rules/do-you-catch-exceptions-precisely)
-- [Do you return the correct response code?](https://www.ssw.com.au/rules/do-you-return-the-correct-response-code)
 - https://ardalis.com/avoid-using-exceptions-determine-api-status/
 - https://blog.nimblepros.com/blogs/getting-started-with-ardalis-result/
 - https://github.com/ardalis/Result

--- a/docs/adr/20240605-use-results-pattern-over-exceptions.md
+++ b/docs/adr/20240605-use-results-pattern-over-exceptions.md
@@ -31,6 +31,8 @@ There are several problems with using exceptions as flow control:
 
 Chosen option: "Option 2 - Use Result Pattern for Validation and Flow Control", because exceptions should only be used for exceptional circumstances, and NOT for flow control.
 
+See the SSW Rule [Do you use the result pattern?](https://www.ssw.com.au/rules/do-you-use-the-result-pattern) for the wider guidance behind this decision.
+
 ### Consequences <!-- optional -->
 
 - Dependency on additional nuget packages
@@ -65,6 +67,9 @@ The result pattern could be implemented via:
 
 ## Links <!-- optional -->
 
+- [Do you use the result pattern?](https://www.ssw.com.au/rules/do-you-use-the-result-pattern)
+- [Do you catch exceptions precisely?](https://www.ssw.com.au/rules/do-you-catch-exceptions-precisely)
+- [Do you return the correct response code?](https://www.ssw.com.au/rules/do-you-return-the-correct-response-code)
 - https://ardalis.com/avoid-using-exceptions-determine-api-status/
 - https://blog.nimblepros.com/blogs/getting-started-with-ardalis-result/
 - https://github.com/ardalis/Result

--- a/docs/adr/20241023-use-net-openapi-and-scalar-over-nswag-and-swagger.md
+++ b/docs/adr/20241023-use-net-openapi-and-scalar-over-nswag-and-swagger.md
@@ -21,6 +21,8 @@ Currently, we use NSwag to generate our OpenAPI (Swagger) specification file. .N
 
 Chosen option: "Option 3 - `Microsoft.AspNetCore.OpenApi` with [Scalar](https://github.com/scalar/scalar)", because we should use the built-in .NET library for generating OpenAPI spec files, and Scalar is a modern, lightweight, and fast alternative to Swagger UI.
 
+See the SSW Rule [Do you document your Web API?](https://www.ssw.com.au/rules/do-you-document-your-webapi), which also names Scalar as an option.
+
 ## Pros and Cons of the Options <!-- optional -->
 
 ### 1. NSwag with Swagger UI
@@ -44,6 +46,8 @@ Chosen option: "Option 3 - `Microsoft.AspNetCore.OpenApi` with [Scalar](https://
 
 ## Links <!-- optional -->
 
+- [Do you document your Web API?](https://www.ssw.com.au/rules/do-you-document-your-webapi)
+- [Do you generate API clients?](https://www.ssw.com.au/rules/generate-api-clients)
 - https://github.com/scalar/scalar
 - https://github.com/RicoSuter/NSwag/
 - https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/aspnetcore-openapi?view=aspnetcore-9.0

--- a/docs/adr/20241118-produce-useful-sql-server-exceptions.md
+++ b/docs/adr/20241118-produce-useful-sql-server-exceptions.md
@@ -30,4 +30,5 @@ See the SSW Rule [Do you use strongly typed database exceptions?](https://www.ss
 
 ## Links
 
-- https://www.ssw.com.au/rules/strongly-typed-database-exceptions
+- [Do you use strongly typed database exceptions?](https://www.ssw.com.au/rules/strongly-typed-database-exceptions)
+- [Do you catch exceptions precisely?](https://www.ssw.com.au/rules/do-you-catch-exceptions-precisely)

--- a/docs/adr/20241118-replace-automapper-with-manual-mapping.md
+++ b/docs/adr/20241118-replace-automapper-with-manual-mapping.md
@@ -52,4 +52,6 @@ Chosen option: "Option 2 - Manual Mapper", because it reduces the runtime errors
 
 ## Links
 
+- [Do you use unique DTOs per use case?](https://www.ssw.com.au/rules/unique-dtos-per-endpoint)
+- [Do you know the difference between data transfer objects and view models?](https://www.ssw.com.au/rules/the-difference-between-data-transfer-objects-and-view-models)
 - https://www.youtube.com/watch?v=RsnEZdc3MrE

--- a/docs/adr/20241118-use-vogen-to-simplify-strongly-typed-ids.md
+++ b/docs/adr/20241118-use-vogen-to-simplify-strongly-typed-ids.md
@@ -24,6 +24,8 @@ Strongly typed IDs are a great way to combat primitive obsession. However, they 
 
 Chosen option: "Option 2 - Vogen", because configuration, validation, and usage of strongly typed IDs is much simpler (espeicially from the EF Core point of view).
 
+The SSW Rule [Do you use Strongly Typed IDs to avoid Primitive Obsession](https://www.ssw.com.au/rules/strongly-typed-ids) covers the manual approach. This ADR picks the library that removes the boilerplate.
+
 ## Pros and Cons of the Options <!-- optional -->
 
 ### Option 1 - Manual Approach
@@ -42,5 +44,7 @@ Chosen option: "Option 2 - Vogen", because configuration, validation, and usage 
 
 ## Links
 
+- [Do you use Strongly Typed IDs to avoid Primitive Obsession](https://www.ssw.com.au/rules/strongly-typed-ids)
+- [Do you know when to use value objects?](https://www.ssw.com.au/rules/when-to-use-value-objects)
 - https://stevedunn.github.io/Vogen/overview.html
 - https://github.com/SteveDunn/Vogen

--- a/docs/adr/20250326-migrate-to-awesome-assertions.md
+++ b/docs/adr/20250326-migrate-to-awesome-assertions.md
@@ -32,7 +32,7 @@ Version 7 will remain fully open-source indefinitely and receive bugfixes and ot
 
 Chosen option: "Option 5 - Awesome Assertions", because we get the same experience as FluentAssertions, but it is free for commercial use. It is also easy to migrate from FluentAssertions to Awesome Assertions.
 
-The SSW Rule [Do you know the most popular unit and integration testing frameworks for .NET](https://www.ssw.com.au/rules/testing-tools) still points at FluentAssertions and Shouldly. It predates the FluentAssertions licence change, so this ADR diverges from it until the rule is updated.
+The SSW Rule [Do you know the most popular unit and integration testing frameworks for .NET applications?](https://www.ssw.com.au/rules/testing-tools) still points at FluentAssertions and Shouldly. It predates the FluentAssertions licence change, so this ADR diverges from it until the rule is updated.
 
 ## Pros and Cons of the Options <!-- optional -->
 
@@ -79,5 +79,5 @@ https://awesomeassertions.org/
 
 ## Links
 
-- [Do you know the most popular unit and integration testing frameworks for .NET](https://www.ssw.com.au/rules/testing-tools)
+- [Do you know the most popular unit and integration testing frameworks for .NET applications?](https://www.ssw.com.au/rules/testing-tools)
 - [Do you follow naming conventions for tests and test projects?](https://www.ssw.com.au/rules/follow-naming-conventions-for-tests-and-test-projects)

--- a/docs/adr/20250326-migrate-to-awesome-assertions.md
+++ b/docs/adr/20250326-migrate-to-awesome-assertions.md
@@ -32,6 +32,8 @@ Version 7 will remain fully open-source indefinitely and receive bugfixes and ot
 
 Chosen option: "Option 5 - Awesome Assertions", because we get the same experience as FluentAssertions, but it is free for commercial use. It is also easy to migrate from FluentAssertions to Awesome Assertions.
 
+The SSW Rule [Do you know the most popular unit and integration testing frameworks for .NET](https://www.ssw.com.au/rules/testing-tools) still points at FluentAssertions and Shouldly. It predates the FluentAssertions licence change, so this ADR diverges from it until the rule is updated.
+
 ## Pros and Cons of the Options <!-- optional -->
 
 ### Option 1 - Shouldly
@@ -74,3 +76,8 @@ https://awesomeassertions.org/
 - ✅ Free for commercial use
 - ✅ Easy to migrate from FluentAssertions
 - ✅ Custom extensions will continue to work (with minor modifications)
+
+## Links
+
+- [Do you know the most popular unit and integration testing frameworks for .NET](https://www.ssw.com.au/rules/testing-tools)
+- [Do you follow naming conventions for tests and test projects?](https://www.ssw.com.au/rules/follow-naming-conventions-for-tests-and-test-projects)

--- a/docs/adr/20260221-use-aggregate-specification-classes-with-factory-methods.md
+++ b/docs/adr/20260221-use-aggregate-specification-classes-with-factory-methods.md
@@ -24,6 +24,8 @@ The previous approach created a separate class file per specification (e.g., `Te
 
 Chosen option: **Option 2 - Single class per aggregate with static factory methods**, because it groups all specifications for an aggregate in one discoverable location and reduces file count without sacrificing clarity.
 
+See the SSW Rule [Do you use the Specification pattern in your software design?](https://www.ssw.com.au/rules/use-specification-pattern) for the pattern itself. This ADR only changes how the specs are organised.
+
 The class itself extends `SingleResultSpecification<T>` and static factory methods configure instances via `spec.Query`, following a consistent naming convention (`{Aggregate}Spec`).
 
 ```csharp
@@ -68,3 +70,8 @@ dbContext.Heroes.WithSpecification(HeroSpec.ById(heroId)).FirstOrDefault();
 - ✅ Consistent naming convention (`{Aggregate}Spec`)
 - ✅ No inner class boilerplate
 - ❌ Slightly more verbose per specification entry
+
+## Links
+
+- [Do you use the Specification pattern in your software design?](https://www.ssw.com.au/rules/use-specification-pattern)
+- [Do you encapsulate domain models in Domain-Driven Design?](https://www.ssw.com.au/rules/encapsulate-domain-models)


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Follow-up to #630, which linked one ADR to its SSW rule. This does the same sweep across the rest of the log.

Reading all 17 ADRs against ssw.com.au/rules turned up 29 relevant rules that weren't referenced anywhere. It also turned up 10 gaps where the rules site either has nothing on the topic or is now out of date. Those gaps are tracked separately in the SAW backlog ([SSWConsulting/SSW.SAW.General#39](https://github.com/SSWConsulting/SSW.SAW.General/issues/39) through [#48](https://github.com/SSWConsulting/SSW.SAW.General/issues/48)) and aren't touched here.

> 2. What was changed?

✏️ Every ADR in `docs/adr` now points at the SSW rules behind its decision, following the shape already set by `20241118-produce-useful-sql-server-exceptions.md`:

- a one-line callout in `## Decision Outcome` naming the most relevant rule
- a `## Links` section listing the rest

Three ADRs deliberately disagree with a published rule, and now say so instead of linking silently:

- **EF Core + Specifications** steps away from [do-you-use-the-repository-pattern-for-data-access](https://www.ssw.com.au/rules/do-you-use-the-repository-pattern-for-data-access), a 2012 rule that the template no longer follows
- **Awesome Assertions** diverges from [testing-tools](https://www.ssw.com.au/rules/testing-tools), which still recommends FluentAssertions and predates its commercial licence change
- **Vogen** extends [strongly-typed-ids](https://www.ssw.com.au/rules/strongly-typed-ids), which only covers the manual approach

None of the decisions, options, or pros and cons were changed. Docs only, no code.

Verification: all 29 slugs were checked against the `SSW.Rules.Content` repo tree, and every URL returns HTTP 200 from ssw.com.au.

> 3. Did you do pair or mob programming?

✏️ No, solo with Claude Code.
